### PR TITLE
feat(frontend): ノードをアコーディオン化してつながりを見やすくする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ workspace/
 # Codex 一時出力（サブエージェント用）
 .claude/tmp/
 .gstack/
+
+# Playwright
+packages/*/.playwright-tally-home/
+packages/*/playwright-report/
+packages/*/test-results/

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,10 @@
       "!**/coverage",
       "!**/*.tsbuildinfo",
       "!**/pnpm-lock.yaml",
-      "!**/examples/**/.tally"
+      "!**/examples/**/.tally",
+      "!**/.playwright-tally-home",
+      "!**/playwright-report",
+      "!**/test-results"
     ]
   },
   "assist": { "actions": { "source": { "organizeImports": "on" } } },

--- a/packages/frontend/e2e/accordion.spec.ts
+++ b/packages/frontend/e2e/accordion.spec.ts
@@ -1,0 +1,111 @@
+import { expect, type Page, test } from '@playwright/test';
+
+// Issue #4: ノードのアコーディオン化。
+// sample-project (TaskFlow 招待機能) を Playwright 専用 TALLY_HOME に登録した状態で、
+// プロジェクトを開き、折りたたみ/展開の UI 挙動を検証する。
+
+// sample-project に含まれる要求ノードの一部。折りたたみ時は見えず、展開すると見える。
+// 「チーム招待機能」(x=40, y=40) は React Flow の fitView 後にツールバー右上と重なる位置に描画
+// されるため、トグルクリックがツールバーに遮られる。ツールバーと干渉しない「権限レベルの柔軟設定」
+// (x=40, y=260) を使う。
+const TARGET_TITLE = '権限レベルの柔軟設定';
+const TARGET_BODY_FRAGMENT = '招待時に権限を指定';
+
+async function openSampleProject(page: Page): Promise<void> {
+  await page.goto('/');
+  // レジストリからの一覧表示を待つ。
+  await page.getByRole('link', { name: /TaskFlow 招待機能追加/ }).click();
+  // キャンバスが描画され React Flow のノード要素が出るまで待つ。
+  await page.locator('.react-flow__node').first().waitFor({ state: 'visible' });
+}
+
+function nodeByTitle(page: Page, title: string) {
+  return page.locator('.react-flow__node').filter({ hasText: title }).first();
+}
+
+test.describe('ノードのアコーディオン', () => {
+  test('プロジェクトを開いた直後は全ノードが折りたたみ状態 (body が見えない)', async ({ page }) => {
+    await openSampleProject(page);
+
+    // タイトル自体は見える。
+    await expect(page.getByText(TARGET_TITLE).first()).toBeVisible();
+
+    // 折りたたみ時は body が DOM に存在しない (body は条件レンダリングで除去される)。
+    // getByText 完全一致でなく "含む" 検索だと他のテキストにマッチしうるため、body 断片のピンポイント確認。
+    await expect(page.getByText(TARGET_BODY_FRAGMENT)).toHaveCount(0);
+  });
+
+  test('トグルボタンをクリックすると個別ノードが展開し body が見える', async ({ page }) => {
+    await openSampleProject(page);
+
+    const node = nodeByTitle(page, TARGET_TITLE);
+    const toggle = node.getByRole('button', { name: '展開' });
+    await expect(toggle).toBeVisible();
+
+    await toggle.click();
+
+    // 展開後は body 断片が描画される。
+    await expect(node.getByText(TARGET_BODY_FRAGMENT)).toBeVisible();
+
+    // 再度クリックすると折りたたみに戻る。
+    const collapseBtn = node.getByRole('button', { name: '折りたたみ' });
+    await expect(collapseBtn).toBeVisible();
+    await collapseBtn.click();
+    await expect(node.getByText(TARGET_BODY_FRAGMENT)).toHaveCount(0);
+  });
+
+  test('ツールバーの「全展開」「全折りたたみ」が全ノードに一括適用される', async ({ page }) => {
+    await openSampleProject(page);
+
+    // 初期: 全ノード折りたたみなので body は 0 件。
+    await expect(page.getByText(TARGET_BODY_FRAGMENT)).toHaveCount(0);
+
+    // 全展開をクリック。
+    await page.getByRole('button', { name: /全展開/ }).click();
+
+    // 複数のノードで body が描画される。検証: ターゲットノードの body が見える。
+    await expect(page.getByText(TARGET_BODY_FRAGMENT)).toHaveCount(1);
+
+    // 展開済みボタン ▾ が複数あることも担保 (ノード数ぶんの「折りたたみ」aria-label が出る)。
+    const collapseBtns = page.locator('.react-flow__node button[aria-label="折りたたみ"]');
+    const count = await collapseBtns.count();
+    expect(count).toBeGreaterThan(3);
+
+    // 全折りたたみで戻す。
+    await page.getByRole('button', { name: /全折りたたみ/ }).click();
+    await expect(page.getByText(TARGET_BODY_FRAGMENT)).toHaveCount(0);
+  });
+
+  test('展開中のノードもドラッグで位置が変わる (トグルボタンがドラッグと競合しない)', async ({
+    page,
+  }) => {
+    await openSampleProject(page);
+
+    // 1 ノードだけ展開してドラッグ可能であることを確認する。
+    const node = nodeByTitle(page, TARGET_TITLE);
+    await node.getByRole('button', { name: '展開' }).click();
+    await expect(node.getByText(TARGET_BODY_FRAGMENT)).toBeVisible();
+
+    const boxBefore = await node.boundingBox();
+    if (!boxBefore) throw new Error('node bounding box not found');
+
+    // タイトル付近 (ボタンから離した位置) を掴んでドラッグ。
+    const startX = boxBefore.x + boxBefore.width / 2;
+    const startY = boxBefore.y + boxBefore.height - 10; // タイトル下端寄り
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    // React Flow はマイクロ動きだとドラッグ判定しないことがあるため十分大きく動かす。
+    await page.mouse.move(startX + 120, startY + 80, { steps: 10 });
+    await page.mouse.up();
+
+    // ドラッグ後に位置が動いていること。
+    const boxAfter = await node.boundingBox();
+    if (!boxAfter) throw new Error('node bounding box not found after drag');
+    const dx = Math.abs(boxAfter.x - boxBefore.x);
+    const dy = Math.abs(boxAfter.y - boxBefore.y);
+    expect(dx + dy).toBeGreaterThan(20);
+
+    // ドラッグ後も展開状態が維持されている (body は見えたまま)。
+    await expect(node.getByText(TARGET_BODY_FRAGMENT)).toBeVisible();
+  });
+});

--- a/packages/frontend/e2e/global-setup.ts
+++ b/packages/frontend/e2e/global-setup.ts
@@ -1,0 +1,41 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+// Playwright の global setup: TALLY_HOME を初期化し、sample-project をコピーして
+// registry.yaml に登録する。dev server は playwright.config の webServer で TALLY_HOME
+// を同じ値に向けて起動する前提。
+export default async function globalSetup(): Promise<void> {
+  const tallyHome = path.resolve(__dirname, '..', '.playwright-tally-home');
+  const projectsRoot = path.join(tallyHome, 'projects');
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const sampleSrc = path.join(repoRoot, 'examples', 'sample-project');
+  const sampleDst = path.join(projectsRoot, 'taskflow-invite');
+
+  // 毎回クリーンな状態から始める (前回ドラッグで位置が変わっていても reset)。
+  await fs.rm(tallyHome, { recursive: true, force: true });
+  await fs.mkdir(projectsRoot, { recursive: true });
+  await copyDir(sampleSrc, sampleDst);
+
+  // registry.yaml を手書き (schema は RegistrySchema と揃える)。
+  const now = new Date().toISOString();
+  const registry = [
+    'version: 1',
+    'projects:',
+    '  - id: taskflow-invite',
+    `    path: ${sampleDst}`,
+    `    lastOpenedAt: ${now}`,
+    '',
+  ].join('\n');
+  await fs.writeFile(path.join(tallyHome, 'registry.yaml'), registry, 'utf8');
+}
+
+async function copyDir(src: string, dst: string): Promise<void> {
+  await fs.mkdir(dst, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const e of entries) {
+    const s = path.join(src, e.name);
+    const d = path.join(dst, e.name);
+    if (e.isDirectory()) await copyDir(s, d);
+    else if (e.isFile()) await fs.copyFile(s, d);
+  }
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,6 +9,8 @@
     "start": "next start",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -27,14 +29,15 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/dagre": "^0.7.54",
     "@types/node": "^24.12.2",
-    "@vitejs/plugin-react": "^6.0.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^6.0.1",
     "jsdom": "^29.0.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"

--- a/packages/frontend/playwright.config.ts
+++ b/packages/frontend/playwright.config.ts
@@ -1,0 +1,45 @@
+import path from 'node:path';
+
+import { defineConfig, devices } from '@playwright/test';
+
+// テスト専用の TALLY_HOME (global-setup 側と同じ値を使う)。
+// registry.yaml とプロジェクトコピーをこの下に作る。
+const TEST_TALLY_HOME = path.resolve(__dirname, '.playwright-tally-home');
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: process.env.CI ? [['list']] : 'list',
+
+  globalSetup: './e2e/global-setup.ts',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // frontend の dev server を自動起動。ai-engine は未起動でもノード表示は動く (chat を開かない限り WS 接続なし)。
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      TALLY_HOME: TEST_TALLY_HOME,
+      // Next.js の開発用ログをある程度抑える。
+      NEXT_TELEMETRY_DISABLED: '1',
+    },
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+});

--- a/packages/frontend/src/components/canvas/canvas.tsx
+++ b/packages/frontend/src/components/canvas/canvas.tsx
@@ -32,6 +32,8 @@ export function Canvas() {
   const connectEdge = useCanvasStore((s) => s.connectEdge);
   const select = useCanvasStore((s) => s.select);
   const autoLayout = useCanvasStore((s) => s.autoLayout);
+  const expandAllNodes = useCanvasStore((s) => s.expandAllNodes);
+  const collapseAllNodes = useCanvasStore((s) => s.collapseAllNodes);
 
   const rfNodes = useMemo<RFNode[]>(
     () =>
@@ -82,6 +84,8 @@ export function Canvas() {
           moveNode={moveNode}
           select={select}
           autoLayout={autoLayout}
+          expandAllNodes={expandAllNodes}
+          collapseAllNodes={collapseAllNodes}
         />
       </div>
     </ReactFlowProvider>
@@ -96,6 +100,8 @@ function CanvasInner(props: {
   moveNode: (id: string, x: number, y: number) => Promise<void>;
   select: (target: { kind: 'node'; id: string } | { kind: 'edge'; id: string } | null) => void;
   autoLayout: (direction?: 'TB' | 'LR') => Promise<void>;
+  expandAllNodes: () => void;
+  collapseAllNodes: () => void;
 }) {
   const { fitView } = useReactFlow();
   const [aligning, setAligning] = useState<null | 'TB' | 'LR'>(null);
@@ -190,6 +196,22 @@ function CanvasInner(props: {
             style={alignButtonStyle(false)}
           >
             🗺 Mermaid
+          </button>
+          <button
+            type="button"
+            onClick={props.expandAllNodes}
+            title="すべてのノードを展開 (詳細表示)"
+            style={alignButtonStyle(false)}
+          >
+            ▾ 全展開
+          </button>
+          <button
+            type="button"
+            onClick={props.collapseAllNodes}
+            title="すべてのノードを折りたたみ (タイトルのみ)"
+            style={alignButtonStyle(false)}
+          >
+            ▸ 全折りたたみ
           </button>
           <button
             type="button"

--- a/packages/frontend/src/components/nodes/coderef-node.tsx
+++ b/packages/frontend/src/components/nodes/coderef-node.tsx
@@ -3,9 +3,11 @@ import { NODE_META } from '@tally/core';
 import type { NodeProps } from '@xyflow/react';
 
 import { NodeBadge, NodeCard } from './node-card';
+import { useNodeAccordion } from './use-accordion';
 
-export function CodeRefNodeView({ data }: NodeProps) {
+export function CodeRefNodeView({ id, data }: NodeProps) {
   const node = (data as { node: CodeRefNode }).node;
+  const { collapsed, toggle } = useNodeAccordion(id);
   const range =
     node.startLine != null
       ? `${node.startLine}${
@@ -33,6 +35,8 @@ export function CodeRefNodeView({ data }: NodeProps) {
       body={node.body}
       badge={badge}
       footer={footer}
+      collapsed={collapsed}
+      onToggleCollapse={toggle}
     />
   );
 }

--- a/packages/frontend/src/components/nodes/issue-node.tsx
+++ b/packages/frontend/src/components/nodes/issue-node.tsx
@@ -3,8 +3,18 @@ import { NODE_META } from '@tally/core';
 import type { NodeProps } from '@xyflow/react';
 
 import { NodeCard } from './node-card';
+import { useNodeAccordion } from './use-accordion';
 
-export function IssueNodeView({ data }: NodeProps) {
+export function IssueNodeView({ id, data }: NodeProps) {
   const node = (data as { node: IssueNode }).node;
-  return <NodeCard meta={NODE_META.issue} title={node.title} body={node.body} />;
+  const { collapsed, toggle } = useNodeAccordion(id);
+  return (
+    <NodeCard
+      meta={NODE_META.issue}
+      title={node.title}
+      body={node.body}
+      collapsed={collapsed}
+      onToggleCollapse={toggle}
+    />
+  );
 }

--- a/packages/frontend/src/components/nodes/node-card.test.tsx
+++ b/packages/frontend/src/components/nodes/node-card.test.tsx
@@ -1,0 +1,77 @@
+import { NODE_META } from '@tally/core';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { ReactFlowProvider } from '@xyflow/react';
+import type { ReactElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { NodeCard } from './node-card';
+
+// React Flow の Handle は ReactFlowProvider 内でなければ warning を出すため wrap する。
+function renderInFlow(el: ReactElement) {
+  return render(<ReactFlowProvider>{el}</ReactFlowProvider>);
+}
+
+describe('NodeCard アコーディオン', () => {
+  it('collapsed=true のとき body と footer を描画しない', () => {
+    renderInFlow(
+      <NodeCard
+        meta={NODE_META.requirement}
+        title="要求A"
+        body="この要求は重要な……（長い説明）"
+        footer={<span>フッタ情報</span>}
+        collapsed={true}
+        onToggleCollapse={() => {}}
+      />,
+    );
+    expect(screen.getByText('要求A')).toBeInTheDocument();
+    expect(screen.queryByText(/この要求は重要な/)).not.toBeInTheDocument();
+    expect(screen.queryByText('フッタ情報')).not.toBeInTheDocument();
+  });
+
+  it('collapsed=false のとき body と footer を描画する', () => {
+    renderInFlow(
+      <NodeCard
+        meta={NODE_META.requirement}
+        title="要求A"
+        body="この要求は重要な本文"
+        footer={<span>フッタ情報</span>}
+        collapsed={false}
+        onToggleCollapse={() => {}}
+      />,
+    );
+    expect(screen.getByText('要求A')).toBeInTheDocument();
+    expect(screen.getByText('この要求は重要な本文')).toBeInTheDocument();
+    expect(screen.getByText('フッタ情報')).toBeInTheDocument();
+  });
+
+  it('トグルボタンのクリックで onToggleCollapse が呼ばれ、親への伝播は止まる', async () => {
+    const toggle = vi.fn();
+    const parentClick = vi.fn();
+    const user = userEvent.setup();
+    renderInFlow(
+      // React Flow のノードは親 div の onClick で選択扱いになるため、
+      // トグルボタンのクリックが親に伝播しないことをここで保証する (実挙動と同じ形)。
+      // button 要素で親を組む: a11y lint を満たしつつクリック伝播の挙動検証ができる。
+      <button type="button" onClick={parentClick}>
+        <NodeCard
+          meta={NODE_META.requirement}
+          title="要求A"
+          body="本文"
+          collapsed={true}
+          onToggleCollapse={toggle}
+        />
+      </button>,
+    );
+    await user.click(screen.getByRole('button', { name: '展開' }));
+    expect(toggle).toHaveBeenCalledTimes(1);
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it('onToggleCollapse 未指定なら トグルボタンは表示されない', () => {
+    renderInFlow(
+      <NodeCard meta={NODE_META.requirement} title="要求A" body="本文" collapsed={true} />,
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/components/nodes/node-card.tsx
+++ b/packages/frontend/src/components/nodes/node-card.tsx
@@ -15,6 +15,10 @@ export interface NodeCardProps {
   accentOverride?: { color: string; accent: string; label: string; icon: string };
   badge?: ReactNode;
   footer?: ReactNode;
+  /** アコーディオン: true なら body / footer を隠しタイトルだけ見せる。キャンバス上でのつながり重視。 */
+  collapsed?: boolean;
+  /** 折りたたみトグル。未指定ならトグルボタンは表示しない。 */
+  onToggleCollapse?: () => void;
 }
 
 const BASE_STYLE: CSSProperties = {
@@ -40,6 +44,8 @@ export function NodeCard({
   accentOverride,
   badge,
   footer,
+  collapsed,
+  onToggleCollapse,
 }: NodeCardProps) {
   const borderWidth = dashed ? 2 : 2;
   const borderStyle = dashed ? 'dashed' : 'solid';
@@ -51,6 +57,11 @@ export function NodeCard({
 
   const headerLabel = accentOverride?.label ?? meta.label;
   const headerIcon = accentOverride?.icon ?? meta.icon;
+
+  // 折りたたみ時はタイトル直下の余白を詰めて一行ラベル感を強める。
+  const titleStyle: CSSProperties = collapsed
+    ? { fontWeight: 700, fontSize: 14, marginBottom: 0 }
+    : { fontWeight: 700, fontSize: 14, marginBottom: 4 };
 
   return (
     <div
@@ -76,10 +87,42 @@ export function NodeCard({
         <span aria-hidden="true">{headerIcon}</span>
         <span>{headerLabel}</span>
         {badge}
+        {onToggleCollapse && (
+          <button
+            type="button"
+            // React Flow のドラッグ/選択に取られないよう nodrag/nopan を付与。
+            // クリックが親 div の onNodeClick に伝わると選択状態が暴れるので stopPropagation。
+            className="nodrag nopan"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleCollapse();
+            }}
+            onPointerDown={(e) => {
+              // React Flow は pointerdown で drag を開始するため、ここでも止めておく。
+              e.stopPropagation();
+            }}
+            aria-label={collapsed ? '展開' : '折りたたみ'}
+            aria-expanded={!collapsed}
+            title={collapsed ? '展開' : '折りたたみ'}
+            style={{
+              // badge がある場合は auto マージン済みなので 0、ない場合は末尾寄せのため auto。
+              marginLeft: badge ? 0 : 'auto',
+              background: 'transparent',
+              border: 'none',
+              color: effectiveAccent,
+              cursor: 'pointer',
+              padding: '0 2px',
+              fontSize: 10,
+              lineHeight: 1,
+            }}
+          >
+            {collapsed ? '▸' : '▾'}
+          </button>
+        )}
       </div>
-      <div style={{ fontWeight: 700, fontSize: 14, marginBottom: 4 }}>{title}</div>
-      {body && <div style={{ color: '#c8d1da' }}>{body}</div>}
-      {footer && <div style={{ marginTop: 8 }}>{footer}</div>}
+      <div style={titleStyle}>{title}</div>
+      {!collapsed && body && <div style={{ color: '#c8d1da' }}>{body}</div>}
+      {!collapsed && footer && <div style={{ marginTop: 8 }}>{footer}</div>}
       <Handle type="source" position={Position.Right} style={{ background: effectiveColor }} />
     </div>
   );

--- a/packages/frontend/src/components/nodes/proposal-node.tsx
+++ b/packages/frontend/src/components/nodes/proposal-node.tsx
@@ -3,12 +3,14 @@ import { NODE_META } from '@tally/core';
 import type { NodeProps } from '@xyflow/react';
 
 import { NodeBadge, NodeCard } from './node-card';
+import { useNodeAccordion } from './use-accordion';
 
 // 提案ノードは破線を保ったまま、adoptAs ヒントの対象型色で縁取りする。
 // これにより「AI提案」という信頼性レイヤー (破線) を維持しつつ、
 // 人間が「何の型として提案されているか」を色・アイコンで一目で判別できる。
-export function ProposalNodeView({ data }: NodeProps) {
+export function ProposalNodeView({ id, data }: NodeProps) {
   const node = (data as { node: ProposalNode }).node;
+  const { collapsed, toggle } = useNodeAccordion(id);
   const targetMeta = node.adoptAs ? NODE_META[node.adoptAs] : null;
   // AI提案とわかるプレフィックス「✦ 提案」＋「→ 要求」などのバッジ。
   const headerLabel = targetMeta ? `✦ 提案 → ${targetMeta.label}` : NODE_META.proposal.label;
@@ -21,6 +23,8 @@ export function ProposalNodeView({ data }: NodeProps) {
     body: node.body,
     dashed: true as const,
     badge,
+    collapsed,
+    onToggleCollapse: toggle,
   };
   if (!targetMeta) return <NodeCard {...commonProps} />;
   return (

--- a/packages/frontend/src/components/nodes/question-node.tsx
+++ b/packages/frontend/src/components/nodes/question-node.tsx
@@ -3,9 +3,11 @@ import { getSelectedOption, isDecided, NODE_META } from '@tally/core';
 import type { NodeProps } from '@xyflow/react';
 
 import { NodeBadge, NodeCard } from './node-card';
+import { useNodeAccordion } from './use-accordion';
 
-export function QuestionNodeView({ data }: NodeProps) {
+export function QuestionNodeView({ id, data }: NodeProps) {
   const node = (data as { node: QuestionNode }).node;
+  const { collapsed, toggle } = useNodeAccordion(id);
   const decided = isDecided(node);
   const selected = getSelectedOption(node);
 
@@ -56,6 +58,8 @@ export function QuestionNodeView({ data }: NodeProps) {
       faded={decided}
       badge={badge}
       footer={footer}
+      collapsed={collapsed}
+      onToggleCollapse={toggle}
     />
   );
 }

--- a/packages/frontend/src/components/nodes/requirement-node.tsx
+++ b/packages/frontend/src/components/nodes/requirement-node.tsx
@@ -3,6 +3,7 @@ import { NODE_META } from '@tally/core';
 import type { NodeProps } from '@xyflow/react';
 
 import { NodeBadge, NodeCard } from './node-card';
+import { useNodeAccordion } from './use-accordion';
 
 const PRIORITY_LABEL: Record<NonNullable<RequirementNode['priority']>, string> = {
   must: 'MUST',
@@ -11,12 +12,20 @@ const PRIORITY_LABEL: Record<NonNullable<RequirementNode['priority']>, string> =
   wont: 'WONT',
 };
 
-export function RequirementNodeView({ data }: NodeProps) {
+export function RequirementNodeView({ id, data }: NodeProps) {
   const node = (data as { node: RequirementNode }).node;
+  const { collapsed, toggle } = useNodeAccordion(id);
   const badge = node.priority ? (
     <NodeBadge tone="info">{PRIORITY_LABEL[node.priority]}</NodeBadge>
   ) : null;
   return (
-    <NodeCard meta={NODE_META.requirement} title={node.title} body={node.body} badge={badge} />
+    <NodeCard
+      meta={NODE_META.requirement}
+      title={node.title}
+      body={node.body}
+      badge={badge}
+      collapsed={collapsed}
+      onToggleCollapse={toggle}
+    />
   );
 }

--- a/packages/frontend/src/components/nodes/use-accordion.ts
+++ b/packages/frontend/src/components/nodes/use-accordion.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useCanvasStore } from '@/lib/store';
+
+// 各ノード種別コンポーネントで共通の「折りたたみ状態とトグル」を返す hook。
+// 折りたたみは UI 状態のみで YAML には永続化しない。キー未設定は折りたたみ扱い。
+export function useNodeAccordion(id: string): {
+  collapsed: boolean;
+  toggle: () => void;
+} {
+  const collapsed = useCanvasStore((s) => !s.expandedNodes[id]);
+  const toggleNodeExpanded = useCanvasStore((s) => s.toggleNodeExpanded);
+  return {
+    collapsed,
+    toggle: () => toggleNodeExpanded(id),
+  };
+}

--- a/packages/frontend/src/components/nodes/usecase-node.tsx
+++ b/packages/frontend/src/components/nodes/usecase-node.tsx
@@ -3,8 +3,18 @@ import { NODE_META } from '@tally/core';
 import type { NodeProps } from '@xyflow/react';
 
 import { NodeCard } from './node-card';
+import { useNodeAccordion } from './use-accordion';
 
-export function UseCaseNodeView({ data }: NodeProps) {
+export function UseCaseNodeView({ id, data }: NodeProps) {
   const node = (data as { node: UseCaseNode }).node;
-  return <NodeCard meta={NODE_META.usecase} title={node.title} body={node.body} />;
+  const { collapsed, toggle } = useNodeAccordion(id);
+  return (
+    <NodeCard
+      meta={NODE_META.usecase}
+      title={node.title}
+      body={node.body}
+      collapsed={collapsed}
+      onToggleCollapse={toggle}
+    />
+  );
 }

--- a/packages/frontend/src/components/nodes/userstory-node.tsx
+++ b/packages/frontend/src/components/nodes/userstory-node.tsx
@@ -3,9 +3,11 @@ import { computeStoryProgress, NODE_META } from '@tally/core';
 import type { NodeProps } from '@xyflow/react';
 
 import { NodeBadge, NodeCard } from './node-card';
+import { useNodeAccordion } from './use-accordion';
 
-export function UserStoryNodeView({ data }: NodeProps) {
+export function UserStoryNodeView({ id, data }: NodeProps) {
   const node = (data as { node: UserStoryNode }).node;
+  const { collapsed, toggle } = useNodeAccordion(id);
   const progress = computeStoryProgress(node);
   const badge = node.points ? <NodeBadge tone="success">{`${node.points}pt`}</NodeBadge> : null;
 
@@ -32,6 +34,8 @@ export function UserStoryNodeView({ data }: NodeProps) {
       body={node.body}
       badge={badge}
       footer={footer}
+      collapsed={collapsed}
+      onToggleCollapse={toggle}
     />
   );
 }

--- a/packages/frontend/src/lib/store.test.ts
+++ b/packages/frontend/src/lib/store.test.ts
@@ -547,6 +547,58 @@ describe('useCanvasStore', () => {
     });
   });
 
+  describe('アコーディオン (expandedNodes)', () => {
+    it('hydrate 直後は全ノード折りたたみ (expandedNodes が空)', () => {
+      expect(useCanvasStore.getState().expandedNodes).toEqual({});
+    });
+
+    it('toggleNodeExpanded で展開⇄折りたたみがトグルする', () => {
+      const { toggleNodeExpanded } = useCanvasStore.getState();
+      toggleNodeExpanded('req-a');
+      expect(useCanvasStore.getState().expandedNodes['req-a']).toBe(true);
+      toggleNodeExpanded('req-a');
+      expect(useCanvasStore.getState().expandedNodes['req-a']).toBeUndefined();
+    });
+
+    it('expandAllNodes はキャンバス上の全ノードを展開する', () => {
+      useCanvasStore.setState({
+        nodes: {
+          'n-1': { id: 'n-1', type: 'requirement', x: 0, y: 0, title: '', body: '' },
+          'n-2': { id: 'n-2', type: 'issue', x: 0, y: 0, title: '', body: '' },
+        },
+      });
+      useCanvasStore.getState().expandAllNodes();
+      expect(useCanvasStore.getState().expandedNodes).toEqual({ 'n-1': true, 'n-2': true });
+    });
+
+    it('collapseAllNodes で expandedNodes が空になる', () => {
+      useCanvasStore.setState({ expandedNodes: { 'req-a': true, 'n-x': true } });
+      useCanvasStore.getState().collapseAllNodes();
+      expect(useCanvasStore.getState().expandedNodes).toEqual({});
+    });
+
+    it('addNodeFromPalette は新規ノードを展開状態で挿入する (空ボディなのでユーザーが編集しやすい)', async () => {
+      const created = {
+        id: 'req-new',
+        type: 'requirement',
+        x: 10,
+        y: 10,
+        title: '',
+        body: '',
+      };
+      okJson(created, 201);
+      await useCanvasStore.getState().addNodeFromPalette('requirement', 10, 10);
+      expect(useCanvasStore.getState().expandedNodes['req-new']).toBe(true);
+    });
+
+    it('removeNode で削除ノードの展開エントリも掃除される', async () => {
+      useCanvasStore.setState({ expandedNodes: { 'req-a': true } });
+      okJson({});
+      await useCanvasStore.getState().removeNode('req-a');
+      expect(useCanvasStore.getState().expandedNodes['req-a']).toBeUndefined();
+    });
+  });
+
   describe('chat threads', () => {
     it('loadChatThreads: API から取得して chatThreadList に保存', async () => {
       okJson({

--- a/packages/frontend/src/lib/store.ts
+++ b/packages/frontend/src/lib/store.ts
@@ -45,6 +45,15 @@ interface CanvasState {
   edges: Record<string, Edge>;
   selected: Selected;
 
+  // UI状態: ノードごとの展開状態 (アコーディオン)。
+  // true = 展開 (body/footer 表示)、キー未設定 or false = 折りたたみ (タイトルのみ)。
+  // デフォルトは折りたたみ。キャンバス上での「ノードのつながり」が見やすくなる。
+  // セッション内のみ保持し YAML には永続化しない。
+  expandedNodes: Record<string, boolean>;
+  toggleNodeExpanded: (id: string) => void;
+  expandAllNodes: () => void;
+  collapseAllNodes: () => void;
+
   hydrate: (project: Project) => void;
   reset: () => void;
   select: (target: Selected) => void;
@@ -316,6 +325,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
     nodes: {},
     edges: {},
     selected: null,
+    expandedNodes: {},
     runningAgent: null,
     chatThreadList: [],
     activeChatThreadId: null,
@@ -330,6 +340,8 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
         nodes: byId(nodes),
         edges: byId(edges),
         selected: null,
+        // プロジェクト切替時は全ノード折りたたみで開始する (つながり重視の初期表示)。
+        expandedNodes: {},
       });
     },
 
@@ -340,10 +352,31 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
         nodes: {},
         edges: {},
         selected: null,
+        expandedNodes: {},
         runningAgent: null,
       }),
 
     select: (target) => set({ selected: target }),
+
+    // 個別ノードの展開状態をトグル。未登録キーは折りたたみ扱いのため true に切り替える。
+    toggleNodeExpanded: (id) => {
+      const cur = get().expandedNodes;
+      if (cur[id]) {
+        // 折りたたむ: キー自体を削除して Record を小さく保つ。
+        const { [id]: _omit, ...rest } = cur;
+        set({ expandedNodes: rest });
+      } else {
+        set({ expandedNodes: { ...cur, [id]: true } });
+      }
+    },
+
+    expandAllNodes: () => {
+      const all: Record<string, boolean> = {};
+      for (const id of Object.keys(get().nodes)) all[id] = true;
+      set({ expandedNodes: all });
+    },
+
+    collapseAllNodes: () => set({ expandedNodes: {} }),
 
     moveNode: async (id, x, y) => {
       const pid = get().projectId;
@@ -395,7 +428,11 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
         title: '',
         body: '',
       } as Omit<Node, 'id'>);
-      set({ nodes: { ...get().nodes, [created.id]: created } });
+      set({
+        nodes: { ...get().nodes, [created.id]: created },
+        // 新規ノードは空なので折りたたんだままだと存在が分かりづらい。展開状態で挿入する。
+        expandedNodes: { ...get().expandedNodes, [created.id]: true },
+      });
       return created;
     },
 
@@ -414,6 +451,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
       }
       // Biome の noDelete 回避のため destructuring で除外する。
       const { [id]: _removedNode, ...remainingNodes } = get().nodes;
+      const { [id]: _removedExpanded, ...remainingExpanded } = get().expandedNodes;
       const prevSelected = get().selected;
       const selectedPointsToThis =
         (prevSelected?.kind === 'node' && prevSelected.id === id) ||
@@ -421,6 +459,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
       set({
         nodes: remainingNodes,
         edges: remainingEdges,
+        expandedNodes: remainingExpanded,
         selected: selectedPointsToThis ? null : prevSelected,
       });
       try {
@@ -672,6 +711,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
       set({
         nodes: {},
         edges: {},
+        expandedNodes: {},
         selected: null,
         chatThreadList: [],
         activeChatThreadId: null,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,7 @@ importers:
         version: 5.1.9
       next:
         specifier: ^16.2.4
-        version: 16.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -113,6 +113,9 @@ importers:
         specifier: ^5.0.0
         version: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -820,6 +823,11 @@ packages:
 
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==}
@@ -1589,6 +1597,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1969,6 +1982,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -2890,6 +2913,10 @@ snapshots:
 
   '@oxc-project/types@0.126.0': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@rolldown/binding-android-arm64@1.0.0-rc.16':
     optional: true
 
@@ -3710,6 +3737,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3998,7 +4028,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@16.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
@@ -4017,6 +4047,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.4
       '@next/swc-win32-arm64-msvc': 16.2.4
       '@next/swc-win32-x64-msvc': 16.2.4
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4063,6 +4094,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   points-on-curve@0.2.0: {}
 


### PR DESCRIPTION
Close #4

## 概要

ノード詳細が長いと「ノードのつながり（エッジ）」が見えにくい問題に対応。ノードをアコーディオン化し、タイトル単位でキャンバス全体のつながりを把握できるようにする。

## 変更点

### UI
- `NodeCard` に `collapsed` / `onToggleCollapse` を追加。折りたたみ時は body / footer を隠してタイトルだけを残す
- ヘッダー右端にトグル (▸ / ▾) を配置。`nodrag nopan` + `stopPropagation` で React Flow のドラッグ/選択と競合させない
- キャンバス右上ツールバーに「▾ 全展開」「▸ 全折りたたみ」ボタンを追加

### 状態管理
- Zustand store に `expandedNodes: Record<string, boolean>` を追加（UI状態のみ・YAML 永続化なし）
- `toggleNodeExpanded(id)` / `expandAllNodes()` / `collapseAllNodes()` アクション
- `hydrate` 直後は全ノード折りたたみで開始（つながり重視の初期表示）
- `addNodeFromPalette` で作った新規ノードは空なので展開状態で挿入
- `removeNode` / `clearBoard` で関連エントリを掃除

### 設計判断
- 既存挙動（常に全展開）より「つながりが見やすい」issue 意図を優先し、デフォルト折りたたみを採用
- UI状態のため YAML やレジストリには保存しない。セッション内でのみ保持

## テスト

- `node-card.test.tsx`: 折りたたみ時に body / footer 非表示、トグルで `onToggleCollapse` 発火、親へ伝播しない、未指定時はボタン出ない
- `store.test.ts`: `toggleNodeExpanded` / `expandAllNodes` / `collapseAllNodes` / hydrate 初期値 / 新規作成時の展開 / 削除時の掃除

全パッケージ 457 テスト通過、typecheck OK、lint の新規エラー 0（既存の `next-env.d.ts` format 1件のみ残存）。

## 動作イメージ

- 既定: すべてのノードがタイトルのみ表示で、エッジによるつながりが一目で見える
- 個別のノードのトグル（▸）をクリックで詳細展開
- ツールバーで一括展開/折りたたみ