### PR TITLE
feat(frontend): キャンバスをスクロールパンに切替えノード操作感を改善

### DIFF
--- a/packages/frontend/e2e/canvas-interaction.spec.ts
+++ b/packages/frontend/e2e/canvas-interaction.spec.ts
@@ -21,9 +21,12 @@ async function openSampleProject(page: Page): Promise<void> {
 // .react-flow__viewport の inline style の transform を取得する。
 // React Flow v12 系は `translate(Xpx, Ypx) scale(Z)` の形式で書き込む。
 async function readViewportTransform(page: Page): Promise<string> {
-  return await page.locator('.react-flow__viewport').first().evaluate((el) => {
-    return (el as HTMLElement).style.transform;
-  });
+  return await page
+    .locator('.react-flow__viewport')
+    .first()
+    .evaluate((el) => {
+      return (el as HTMLElement).style.transform;
+    });
 }
 
 // transform 文字列から translate(x, y) を抽出。scale 部分は無視する。

--- a/packages/frontend/e2e/canvas-interaction.spec.ts
+++ b/packages/frontend/e2e/canvas-interaction.spec.ts
@@ -1,0 +1,115 @@
+import { expect, type Page, test } from '@playwright/test';
+
+// Issue #12 / PR #15: キャンバスをスクロールパンに切替えノード操作感を改善。
+//
+// このテストは「思考のキャンバス」の操作感を担保する。検証する不変条件:
+//  1. ペイン (キャンバス背面) は default カーソル (パンは DnD ではなくスクロールに集約)
+//  2. ノード DOM はホバーで grab カーソル
+//  3. wheel イベントで縦方向にパン (.react-flow__viewport の transform が変化)
+//  4. Shift+wheel で横方向にパン (transform の translateX が変化)
+
+const TARGET_TITLE = '権限レベルの柔軟設定';
+
+async function openSampleProject(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.getByRole('link', { name: /TaskFlow 招待機能追加/ }).click();
+  // React Flow のノード描画と viewport の transform 反映 (fitView) を待つ。
+  await page.locator('.react-flow__node').first().waitFor({ state: 'visible' });
+  await page.locator('.react-flow__viewport').first().waitFor({ state: 'attached' });
+}
+
+// .react-flow__viewport の inline style の transform を取得する。
+// React Flow は `translate(x, y) scale(z)` の形式で書き込む。
+async function readViewportTransform(page: Page): Promise<string> {
+  return await page.locator('.react-flow__viewport').first().evaluate((el) => {
+    return (el as HTMLElement).style.transform;
+  });
+}
+
+// transform 文字列から translate(x, y) を抽出。scale 部分は無視する。
+function parseTranslate(transform: string): { x: number; y: number } {
+  const m = /translate\(\s*(-?[\d.]+)px\s*,\s*(-?[\d.]+)px\s*\)/.exec(transform);
+  if (!m) return { x: 0, y: 0 };
+  return { x: Number(m[1]), y: Number(m[2]) };
+}
+
+test.describe('キャンバス操作感 (cursor / scroll-pan)', () => {
+  test('ペインは default カーソル、ノードは grab カーソル', async ({ page }) => {
+    await openSampleProject(page);
+
+    // ペイン: パンを DnD から外したので default が当たっているはず。
+    const paneCursor = await page
+      .locator('.react-flow__pane')
+      .first()
+      .evaluate((el) => getComputedStyle(el).cursor);
+    expect(paneCursor).toBe('default');
+
+    // ノード: ホバーで grab。getComputedStyle はホバー擬似クラスでなく実際の cursor 値を返すので、
+    // CSS で `.react-flow__node { cursor: grab }` が当たっていることを直接確認する。
+    const nodeCursor = await page
+      .locator('.react-flow__node')
+      .filter({ hasText: TARGET_TITLE })
+      .first()
+      .evaluate((el) => getComputedStyle(el).cursor);
+    expect(nodeCursor).toBe('grab');
+  });
+
+  test('wheel で縦方向にパンすると viewport の transform が変化する', async ({ page }) => {
+    await openSampleProject(page);
+
+    const before = parseTranslate(await readViewportTransform(page));
+
+    // ペイン上で wheel を発火。React Flow は panOnScroll で deltaY を縦パンに変換する。
+    const pane = page.locator('.react-flow__pane').first();
+    const box = await pane.boundingBox();
+    if (!box) throw new Error('pane bounding box not found');
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+
+    // Playwright の mouse.wheel は wheel イベントを正しく発火し、React Flow が拾える。
+    await page.mouse.move(cx, cy);
+    await page.mouse.wheel(0, 200);
+
+    // transform 反映は React Flow の内部 RAF を経由するので、変化を polling で待つ。
+    await expect
+      .poll(async () => parseTranslate(await readViewportTransform(page)).y, {
+        timeout: 2000,
+      })
+      .not.toBe(before.y);
+
+    const after = parseTranslate(await readViewportTransform(page));
+    // 縦パンなので y が変わっている (符号は React Flow 内部実装に依存するので絶対値で見る)。
+    expect(Math.abs(after.y - before.y)).toBeGreaterThan(10);
+  });
+
+  test('Shift+wheel で横方向にパンすると viewport の translateX が変化する', async ({ page }) => {
+    await openSampleProject(page);
+
+    const before = parseTranslate(await readViewportTransform(page));
+
+    const pane = page.locator('.react-flow__pane').first();
+    const box = await pane.boundingBox();
+    if (!box) throw new Error('pane bounding box not found');
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+
+    await page.mouse.move(cx, cy);
+    // Shift を押しながら wheel を発火。Playwright の mouse.wheel は modifiers を直接持たないため、
+    // keyboard.down('Shift') で押下状態を作る。React Flow / ブラウザは shift+deltaY を deltaX 相当として扱う。
+    await page.keyboard.down('Shift');
+    try {
+      await page.mouse.wheel(0, 200);
+    } finally {
+      await page.keyboard.up('Shift');
+    }
+
+    await expect
+      .poll(async () => parseTranslate(await readViewportTransform(page)).x, {
+        timeout: 2000,
+      })
+      .not.toBe(before.x);
+
+    const after = parseTranslate(await readViewportTransform(page));
+    expect(Math.abs(after.x - before.x)).toBeGreaterThan(10);
+  });
+});

--- a/packages/frontend/e2e/canvas-interaction.spec.ts
+++ b/packages/frontend/e2e/canvas-interaction.spec.ts
@@ -8,18 +8,18 @@ import { expect, type Page, test } from '@playwright/test';
 //  3. wheel イベントで縦方向にパン (.react-flow__viewport の transform が変化)
 //  4. Shift+wheel で横方向にパン (transform の translateX が変化)
 
-const TARGET_TITLE = '権限レベルの柔軟設定';
-
 async function openSampleProject(page: Page): Promise<void> {
   await page.goto('/');
   await page.getByRole('link', { name: /TaskFlow 招待機能追加/ }).click();
   // React Flow のノード描画と viewport の transform 反映 (fitView) を待つ。
+  // 後続テストはノードが 1 件以上存在することを暗黙の前提とするため、ここで明示的に保証する。
+  await expect(page.locator('.react-flow__node')).not.toHaveCount(0);
   await page.locator('.react-flow__node').first().waitFor({ state: 'visible' });
   await page.locator('.react-flow__viewport').first().waitFor({ state: 'attached' });
 }
 
 // .react-flow__viewport の inline style の transform を取得する。
-// React Flow は `translate(x, y) scale(z)` の形式で書き込む。
+// React Flow v12 系は `translate(Xpx, Ypx) scale(Z)` の形式で書き込む。
 async function readViewportTransform(page: Page): Promise<string> {
   return await page.locator('.react-flow__viewport').first().evaluate((el) => {
     return (el as HTMLElement).style.transform;
@@ -27,9 +27,16 @@ async function readViewportTransform(page: Page): Promise<string> {
 }
 
 // transform 文字列から translate(x, y) を抽出。scale 部分は無視する。
+// 前提: React Flow v12 系の `translate(Xpx, Ypx) scale(Z)` 形式。
+// パース失敗時は黙って 0 を返さず throw する。CSS 形式が変わった場合に
+// 偽陰性 (transform 不変判定で誤合格) を起こさず、即座に気付けるようにするため。
 function parseTranslate(transform: string): { x: number; y: number } {
   const m = /translate\(\s*(-?[\d.]+)px\s*,\s*(-?[\d.]+)px\s*\)/.exec(transform);
-  if (!m) return { x: 0, y: 0 };
+  if (!m) {
+    throw new Error(
+      `viewport transform が想定形式 (translate(Xpx, Ypx) scale(Z)) ではない: ${JSON.stringify(transform)}`,
+    );
+  }
   return { x: Number(m[1]), y: Number(m[2]) };
 }
 
@@ -46,9 +53,9 @@ test.describe('キャンバス操作感 (cursor / scroll-pan)', () => {
 
     // ノード: ホバーで grab。getComputedStyle はホバー擬似クラスでなく実際の cursor 値を返すので、
     // CSS で `.react-flow__node { cursor: grab }` が当たっていることを直接確認する。
+    // 特定タイトルへの依存はフィクスチャ脆弱性を生むため、最初の 1 件で十分。
     const nodeCursor = await page
       .locator('.react-flow__node')
-      .filter({ hasText: TARGET_TITLE })
       .first()
       .evaluate((el) => getComputedStyle(el).cursor);
     expect(nodeCursor).toBe('grab');
@@ -95,7 +102,10 @@ test.describe('キャンバス操作感 (cursor / scroll-pan)', () => {
 
     await page.mouse.move(cx, cy);
     // Shift を押しながら wheel を発火。Playwright の mouse.wheel は modifiers を直接持たないため、
-    // keyboard.down('Shift') で押下状態を作る。React Flow / ブラウザは shift+deltaY を deltaX 相当として扱う。
+    // keyboard.down('Shift') で押下状態を作る。
+    // 前提: Shift+wheel はブラウザが deltaX として扱い、panOnScrollMode=Free が translateX を動かす。
+    // 注意: CI ヘッドレス環境 (Chromium / Firefox / WebKit / OS) で deltaX 振替の挙動が変わる可能性があり、
+    // 将来的に flake が出た場合はここを疑う (代替案: page.mouse.wheel に直接 deltaX を渡す等)。
     await page.keyboard.down('Shift');
     try {
       await page.mouse.wheel(0, 200);

--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -15,3 +15,23 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+/*
+ * React Flow キャンバスの操作感調整 (issue #12)
+ * - パン操作はスクロールに集約したため、ペイン上は default カーソル。
+ * - ノード上はホバーで grab、ドラッグ中は grabbing。
+ * - ドラッグ中のノードは半透明にして「掴んでいる」フィードバックを強める (ゴーストイメージ)。
+ */
+.react-flow__pane {
+  cursor: default;
+}
+
+.react-flow__node {
+  cursor: grab;
+}
+
+.react-flow__node.dragging,
+.react-flow__node.draggable.dragging {
+  cursor: grabbing;
+  opacity: 0.7;
+}

--- a/packages/frontend/src/app/globals.test.ts
+++ b/packages/frontend/src/app/globals.test.ts
@@ -1,0 +1,24 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// issue #12: キャンバスの操作感を CSS で担保する。
+// React Flow のクラスを globals.css で上書きしているため、
+// 必要なルールが消えていないことをテストで担保する。
+describe('globals.css のキャンバス操作ルール', () => {
+  it('React Flow キャンバスの操作感ルールがすべて含まれている', async () => {
+    const css = await readFile(path.resolve(__dirname, 'globals.css'), 'utf8');
+
+    // panOnDrag=false の前提で、ペインは default カーソル。
+    expect(css).toMatch(/\.react-flow__pane\s*\{[^}]*cursor:\s*default/);
+    // ノードホバーは grab。
+    expect(css).toMatch(/\.react-flow__node\s*\{[^}]*cursor:\s*grab/);
+    // ドラッグ中は grabbing + 半透明 (ゴーストイメージ風)。
+    expect(css).toMatch(/\.react-flow__node\.dragging[^{]*\{[^}]*cursor:\s*grabbing/);
+    expect(css).toMatch(/\.react-flow__node\.dragging[^{]*\{[^}]*opacity:\s*0\.7/);
+  });
+});

--- a/packages/frontend/src/app/globals.test.ts
+++ b/packages/frontend/src/app/globals.test.ts
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // issue #12: キャンバスの操作感を CSS で担保する。
 // React Flow のクラスを globals.css で上書きしているため、
 // 必要なルールが消えていないことをテストで担保する。
+// TODO: React 19 + RTL 互換が解決したら、ソーステキスト読取ではなく実 DOM の getComputedStyle で検証する。
 describe('globals.css のキャンバス操作ルール', () => {
   it('React Flow キャンバスの操作感ルールがすべて含まれている', async () => {
     const css = await readFile(path.resolve(__dirname, 'globals.css'), 'utf8');

--- a/packages/frontend/src/components/canvas/canvas.test.ts
+++ b/packages/frontend/src/components/canvas/canvas.test.ts
@@ -1,0 +1,22 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// issue #12: Canvas の React Flow に渡す操作系 props は UX の根幹。
+// 実際の React Flow のレンダリングは jsdom で重く脆い (現状 React 19 互換性問題で
+// react-testing-library 経由のレンダリング自体が失敗する) ため、
+// ソース上の props 設定をテキストレベルで検証する。
+// 設定が消えれば本テストが落ちて気付ける。
+describe('canvas.tsx の React Flow props (issue #12)', () => {
+  it('panOnDrag=false / panOnScroll / panOnScrollMode=Free / zoomOnScroll=false が指定されている', async () => {
+    const src = await readFile(path.resolve(__dirname, 'canvas.tsx'), 'utf8');
+    expect(src).toMatch(/panOnDrag=\{false\}/);
+    expect(src).toMatch(/panOnScroll(?!Mode)\s*$|panOnScroll(?!Mode)\s*\n/m);
+    expect(src).toMatch(/panOnScrollMode=\{PanOnScrollMode\.Free\}/);
+    expect(src).toMatch(/zoomOnScroll=\{false\}/);
+  });
+});

--- a/packages/frontend/src/components/canvas/canvas.test.ts
+++ b/packages/frontend/src/components/canvas/canvas.test.ts
@@ -11,11 +11,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // react-testing-library 経由のレンダリング自体が失敗する) ため、
 // ソース上の props 設定をテキストレベルで検証する。
 // 設定が消えれば本テストが落ちて気付ける。
+// TODO: React 19 + RTL 互換が解決したら、ソーステキスト読取ではなく実 DOM 検証に切替予定。
 describe('canvas.tsx の React Flow props (issue #12)', () => {
   it('panOnDrag=false / panOnScroll / panOnScrollMode=Free / zoomOnScroll=false が指定されている', async () => {
     const src = await readFile(path.resolve(__dirname, 'canvas.tsx'), 'utf8');
+    // 意図: 各 prop が「指定されている」ことだけを担保する。
+    // 値の形式 (shorthand boolean / `={true}` / `={someVar}`) には依存しない。
+    // panOnScroll は panOnScrollMode と前方一致するため、否定先読みで識別子境界を切る。
     expect(src).toMatch(/panOnDrag=\{false\}/);
-    expect(src).toMatch(/panOnScroll(?!Mode)\s*$|panOnScroll(?!Mode)\s*\n/m);
+    expect(src).toMatch(/\bpanOnScroll\b(?!Mode)/);
     expect(src).toMatch(/panOnScrollMode=\{PanOnScrollMode\.Free\}/);
     expect(src).toMatch(/zoomOnScroll=\{false\}/);
   });

--- a/packages/frontend/src/components/canvas/canvas.tsx
+++ b/packages/frontend/src/components/canvas/canvas.tsx
@@ -7,6 +7,7 @@ import {
   type NodeChange,
   type OnConnect,
   Panel,
+  PanOnScrollMode,
   ReactFlow,
   ReactFlowProvider,
   type Edge as RFEdge,
@@ -137,6 +138,15 @@ function CanvasInner(props: {
       nodesDraggable
       nodesConnectable
       elementsSelectable
+      // キャンバスの移動は DnD ではなくスクロールに統一する (issue #12)。
+      // 通常スクロール = 縦パン、Shift + スクロール = 横パン
+      // (React Flow が macOS 以外で deltaY を deltaX に振り替える)。
+      // ズームは Ctrl/Cmd + スクロール またはピンチ、Controls のボタンに集約する。
+      panOnDrag={false}
+      panOnScroll
+      panOnScrollMode={PanOnScrollMode.Free}
+      zoomOnScroll={false}
+      zoomOnPinch
       proOptions={{ hideAttribution: true }}
       onNodesChange={props.onNodesChange}
       onNodeDragStop={(_evt, node) => {


### PR DESCRIPTION
## Summary

issue #12 対応。キャンバスのパン操作を DnD からスクロールに変更し、ノード操作のフィードバックを強化した。

- **パン操作の変更**: React Flow を `panOnDrag={false}` / `panOnScroll` / `panOnScrollMode=Free` / `zoomOnScroll={false}` に設定。通常スクロールで縦パン、Shift + スクロールで横パン (React Flow が macOS 以外で `deltaY` を `deltaX` に振り替えるため自然に動作する)。ズームは Ctrl/Cmd + スクロール またはピンチ、Controls のボタンに集約。
- **カーソルのフィードバック**: `globals.css` で React Flow のクラスを上書き。ペインは `default`、ノードホバーで `grab`、ドラッグ中で `grabbing`。
- **ゴーストイメージ風フィードバック**: ドラッグ中ノードに `opacity: 0.7` を当てて「掴んでいる」感を強める。
- **テスト追加**: `globals.css` と `canvas.tsx` の操作系設定が将来の編集で消えないよう、ソース文字列ベースで担保するテストを追加。

issue 本文の「アプリケーションの方針に沿っているか検討が必要な提案」は、ユーザー承認済みの方針として全項目を実装した (ペイン: `default` / ノード: `grab` / ドラッグ中: `grabbing`)。

## Test plan

- [x] `pnpm exec vitest run src/app/globals.test.ts` 通過
- [x] `pnpm exec vitest run src/components/canvas/canvas.test.ts` 通過
- [x] `pnpm typecheck` 通過 (frontend)
- [x] `pnpm -r build` 通過 (Next.js build 成功)
- [x] `pnpm lint` で本変更による新規警告なし
- [x] `pnpm dev` 起動 / `GET /` が 200 を返す
- [ ] **未実施 (要レビュアー手動確認)**: ブラウザで以下を確認
  - [ ] ペイン上で **マウスドラッグしてもキャンバスが動かない** (= スクロールに統一されている)
  - [ ] **マウスホイール = 縦パン**、**Shift + ホイール = 横パン**
  - [ ] **Ctrl/Cmd + ホイール = ズーム**、Controls の +/- ボタンでもズームできる
  - [ ] ペイン上のカーソルが `default`
  - [ ] ノードホバーでカーソルが `grab`、ドラッグ中で `grabbing`
  - [ ] ドラッグ中のノードが半透明 (opacity 0.7) になり「掴んでいる」感がある

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * キャンバスのスクロール操作でのパンを改善（標準スクロールで縦パン、Shift+スクロールで横パンをサポート）
  * マウスカーソルフィードバックを追加：デフォルト、ノードホバー時はgrab、ドラッグ中はgrabbing（透明度低下あり）
  * スクロールホイールによるズームを無効化（Ctrl/Cmdやピンチによるズームは継続）

* **テスト**
  * キャンバスインタラクションのE2E検証を追加（カーソル・パン挙動・スクロール操作の検証）
  * スタイルと設定を検証するユニットテストを追加

* **ドキュメント**
  * キャンバス挙動に関するコメントを明確化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->