### PR TITLE
feat: Chatにノードをコンテキストとして添付できるようにする (#11)

### DIFF
--- a/packages/ai-engine/src/chat-runner.test.ts
+++ b/packages/ai-engine/src/chat-runner.test.ts
@@ -225,9 +225,90 @@ describe('ChatRunner', () => {
     expect(capturedPrompt).toContain('type: requirement');
     expect(capturedPrompt).toContain('title: 招待メールから登録できる');
     expect(capturedPrompt).toContain('priority: must');
-    // user メッセージは履歴に積まれている (runUserTurn 内で空 assistant が後置されるため
-    // current_user_message ではなく conversation_history に入る既存挙動)。
-    expect(capturedPrompt).toContain('この要求を分解してほしい');
+    // codex セカンドオピニオン #16 修正後: user メッセージは <current_user_message> に入る。
+    // <context_nodes> ブロックは <current_user_message> より前に位置する。
+    expect(capturedPrompt).toContain('<current_user_message>');
+    const ctxIdx = capturedPrompt.indexOf('<context_nodes>');
+    const curIdx = capturedPrompt.indexOf('<current_user_message>');
+    expect(ctxIdx).toBeGreaterThanOrEqual(0);
+    expect(curIdx).toBeGreaterThan(ctxIdx);
+    // 「この要求を分解してほしい」は current_user_message ブロック内にある。
+    expect(capturedPrompt.slice(curIdx)).toContain('この要求を分解してほしい');
+    // 履歴に user 入力が紛れていない (今回が初ターンなので conversation_history 自体が出ない)。
+    expect(capturedPrompt).not.toContain('<conversation_history>');
+  });
+
+  // codex セカンドオピニオン #16 (ロジックバグ): runUserTurn は内部で空 assistant message を
+  // append するため、prompt 組立を append 前にスナップショットしないと末尾が assistant となり
+  // <current_user_message> が出ず、<context_nodes> が user 入力の後ろに並ぶ問題があった。
+  // この回帰を防ぐ:
+  //   1) <context_nodes> ブロックが <current_user_message> より前にある
+  //   2) 今ターンの user 入力が <conversation_history> 内に出現しない (= 履歴に埋もれていない)
+  it('runUserTurn: <context_nodes> は <current_user_message> より前、user 入力は履歴に埋もれない', async () => {
+    const chatStore = new FileSystemChatStore(root);
+    const projectStore = new FileSystemProjectStore(root);
+    const thread = await chatStore.createChat({ projectId: 'proj-1', title: 't' });
+
+    // 過去ターンを 1 往復仕込む。新しい user 入力が conversation_history に紛れないことを
+    // この過去 user 入力の有無と対比して確認するため。
+    await chatStore.appendMessage(thread.id, {
+      id: newChatMessageId(),
+      role: 'user',
+      blocks: [{ type: 'text', text: '過去のユーザー発話' }],
+      createdAt: new Date().toISOString(),
+    });
+    await chatStore.appendMessage(thread.id, {
+      id: newChatMessageId(),
+      role: 'assistant',
+      blocks: [{ type: 'text', text: '過去のアシスタント応答' }],
+      createdAt: new Date().toISOString(),
+    });
+
+    const target = (await projectStore.addNode({
+      type: 'requirement',
+      x: 0,
+      y: 0,
+      title: 'T1',
+      body: '',
+    })) as Node;
+
+    let capturedPrompt = '';
+    const sdk: SdkLike = {
+      query: ({ prompt }: { prompt: string }) => {
+        capturedPrompt = prompt;
+        return (async function* () {
+          yield { type: 'result', subtype: 'success', result: 'ok' } as unknown as SdkMessageLike;
+        })();
+      },
+    };
+    const runner = new ChatRunner({
+      sdk,
+      chatStore,
+      projectStore,
+      projectDir: root,
+      threadId: thread.id,
+    });
+
+    const NEW_USER_TEXT = '今ターンの新しい入力XYZ';
+    for await (const _e of runner.runUserTurn(NEW_USER_TEXT, [target.id])) {
+      // drain
+    }
+
+    const histIdx = capturedPrompt.indexOf('<conversation_history>');
+    const histEndIdx = capturedPrompt.indexOf('</conversation_history>');
+    const ctxIdx = capturedPrompt.indexOf('<context_nodes>');
+    const curIdx = capturedPrompt.indexOf('<current_user_message>');
+
+    // 順序: history → context → current
+    expect(histIdx).toBeGreaterThanOrEqual(0);
+    expect(ctxIdx).toBeGreaterThan(histIdx);
+    expect(curIdx).toBeGreaterThan(ctxIdx);
+
+    // 今ターンの user 入力は <current_user_message> ブロック内にあり、conversation_history には無い。
+    const historyBlock = capturedPrompt.slice(histIdx, histEndIdx);
+    expect(historyBlock).toContain('過去のユーザー発話');
+    expect(historyBlock).not.toContain(NEW_USER_TEXT);
+    expect(capturedPrompt.slice(curIdx)).toContain(NEW_USER_TEXT);
   });
 
   // 不在 ID は黙って捨てる: 削除済みノードを混ぜても他のノードは渡る + エラーにならない。
@@ -320,6 +401,28 @@ describe('formatNodeForContext / buildChatPrompt', () => {
     expect(out).toContain('* メールリンク');
     expect(out).toContain('- 電話SMS');
     expect(out).toContain('decision: opt-1');
+  });
+
+  it('formatNodeForContext: proposal は未採用注釈と adoptAs を含み sourceAgentId は含まない', () => {
+    // codex セカンドオピニオン #16: proposal の sourceAgentId は AI にとって意味の無い内部属性。
+    // 代わりに「未採用の AI 提案」であることを note として AI に伝える (ADR-0005)。
+    const node: Node = {
+      id: 'p-1',
+      type: 'proposal',
+      x: 0,
+      y: 0,
+      title: '[AI] 提案タイトル',
+      body: '提案ボディ',
+      adoptAs: 'requirement',
+      sourceAgentId: 'agent-decompose-to-stories',
+    };
+    const out = formatNodeForContext(node);
+    expect(out).toContain('id: p-1');
+    expect(out).toContain('type: proposal');
+    expect(out).toContain('未採用の AI 提案');
+    expect(out).toContain('adoptAs: requirement');
+    expect(out).not.toContain('sourceAgentId');
+    expect(out).not.toContain('agent-decompose-to-stories');
   });
 
   it('formatNodeForContext: coderef の filePath/startLine などを含む', () => {

--- a/packages/ai-engine/src/chat-runner.test.ts
+++ b/packages/ai-engine/src/chat-runner.test.ts
@@ -350,7 +350,7 @@ describe('ChatRunner', () => {
   });
 
   // contextNodeIds が空 (または省略) なら <context_nodes> ブロックは生成しない。
-  it('contextNodeIds 空のとき <context_nodes> は出ない (後方互換)', async () => {
+  it('contextNodeIds 空のとき <context_nodes> は出ない', async () => {
     const chatStore = new FileSystemChatStore(root);
     const projectStore = new FileSystemProjectStore(root);
     const thread = await chatStore.createChat({ projectId: 'proj-1', title: 't' });

--- a/packages/ai-engine/src/chat-runner.test.ts
+++ b/packages/ai-engine/src/chat-runner.test.ts
@@ -2,12 +2,13 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import type { Node } from '@tally/core';
 import { newChatMessageId } from '@tally/core';
 import { FileSystemChatStore, FileSystemProjectStore } from '@tally/storage';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { SdkLike } from './agent-runner';
-import { ChatRunner } from './chat-runner';
+import { buildChatPrompt, ChatRunner, formatNodeForContext } from './chat-runner';
 import type { ChatEvent, SdkMessageLike } from './stream';
 
 describe('ChatRunner', () => {
@@ -173,5 +174,200 @@ describe('ChatRunner', () => {
 
     const resultEvt = events.find((e) => e.type === 'chat_tool_result');
     expect(resultEvt?.type === 'chat_tool_result' && resultEvt.ok === false).toBe(true);
+  });
+
+  // issue #11: contextNodeIds を runUserTurn に渡したとき、prompt の <context_nodes>
+  // ブロックに該当ノードの内容が埋め込まれて SDK に届くことを担保する。
+  it('contextNodeIds 指定時: prompt に <context_nodes> ブロックが入り SDK の prompt に届く', async () => {
+    const chatStore = new FileSystemChatStore(root);
+    const projectStore = new FileSystemProjectStore(root);
+    const thread = await chatStore.createChat({ projectId: 'proj-1', title: 't' });
+
+    // 添付対象ノードを 1 件作る (requirement)。
+    const target = (await projectStore.addNode({
+      type: 'requirement',
+      x: 0,
+      y: 0,
+      title: '招待メールから登録できる',
+      body: '既存ユーザが新規ユーザを招待できる',
+      priority: 'must',
+    })) as Node;
+
+    let capturedPrompt = '';
+    const sdk: SdkLike = {
+      query: ({ prompt }: { prompt: string }) => {
+        capturedPrompt = prompt;
+        return (async function* () {
+          yield {
+            type: 'assistant',
+            message: { content: [{ type: 'text', text: 'OK' }] },
+          } as unknown as SdkMessageLike;
+          yield { type: 'result', subtype: 'success', result: 'ok' } as unknown as SdkMessageLike;
+        })();
+      },
+    };
+
+    const runner = new ChatRunner({
+      sdk,
+      chatStore,
+      projectStore,
+      projectDir: root,
+      threadId: thread.id,
+    });
+
+    const events: ChatEvent[] = [];
+    for await (const e of runner.runUserTurn('この要求を分解してほしい', [target.id])) {
+      events.push(e);
+    }
+
+    expect(capturedPrompt).toContain('<context_nodes>');
+    expect(capturedPrompt).toContain(`id: ${target.id}`);
+    expect(capturedPrompt).toContain('type: requirement');
+    expect(capturedPrompt).toContain('title: 招待メールから登録できる');
+    expect(capturedPrompt).toContain('priority: must');
+    // user メッセージは履歴に積まれている (runUserTurn 内で空 assistant が後置されるため
+    // current_user_message ではなく conversation_history に入る既存挙動)。
+    expect(capturedPrompt).toContain('この要求を分解してほしい');
+  });
+
+  // 不在 ID は黙って捨てる: 削除済みノードを混ぜても他のノードは渡る + エラーにならない。
+  it('contextNodeIds に不在 ID が混ざっても残りは prompt に入る', async () => {
+    const chatStore = new FileSystemChatStore(root);
+    const projectStore = new FileSystemProjectStore(root);
+    const thread = await chatStore.createChat({ projectId: 'proj-1', title: 't' });
+    const valid = (await projectStore.addNode({
+      type: 'usecase',
+      x: 0,
+      y: 0,
+      title: 'UC1',
+      body: '',
+    })) as Node;
+
+    let capturedPrompt = '';
+    const sdk: SdkLike = {
+      query: ({ prompt }: { prompt: string }) => {
+        capturedPrompt = prompt;
+        return (async function* () {
+          yield { type: 'result', subtype: 'success', result: 'ok' } as unknown as SdkMessageLike;
+        })();
+      },
+    };
+    const runner = new ChatRunner({
+      sdk,
+      chatStore,
+      projectStore,
+      projectDir: root,
+      threadId: thread.id,
+    });
+    for await (const _e of runner.runUserTurn('q', ['nonexistent', valid.id, 'also-gone'])) {
+      // drain
+    }
+    expect(capturedPrompt).toContain('<context_nodes>');
+    expect(capturedPrompt).toContain(`id: ${valid.id}`);
+    expect(capturedPrompt).not.toContain('id: nonexistent');
+    expect(capturedPrompt).not.toContain('id: also-gone');
+  });
+
+  // contextNodeIds が空 (または省略) なら <context_nodes> ブロックは生成しない。
+  it('contextNodeIds 空のとき <context_nodes> は出ない (後方互換)', async () => {
+    const chatStore = new FileSystemChatStore(root);
+    const projectStore = new FileSystemProjectStore(root);
+    const thread = await chatStore.createChat({ projectId: 'proj-1', title: 't' });
+
+    let capturedPrompt = '';
+    const sdk: SdkLike = {
+      query: ({ prompt }: { prompt: string }) => {
+        capturedPrompt = prompt;
+        return (async function* () {
+          yield { type: 'result', subtype: 'success', result: 'ok' } as unknown as SdkMessageLike;
+        })();
+      },
+    };
+    const runner = new ChatRunner({
+      sdk,
+      chatStore,
+      projectStore,
+      projectDir: root,
+      threadId: thread.id,
+    });
+    for await (const _e of runner.runUserTurn('hello', [])) {
+      // drain
+    }
+    expect(capturedPrompt).not.toContain('<context_nodes>');
+    // user 文字列自体は (履歴経由で) 必ず prompt に入る
+    expect(capturedPrompt).toContain('hello');
+  });
+});
+
+describe('formatNodeForContext / buildChatPrompt', () => {
+  it('formatNodeForContext: question の options を *(selected) / -(unselected) で示す', () => {
+    const node: Node = {
+      id: 'q-1',
+      type: 'question',
+      x: 0,
+      y: 0,
+      title: '招待時の認証方式',
+      body: '',
+      options: [
+        { id: 'opt-1', text: 'メールリンク', selected: true },
+        { id: 'opt-2', text: '電話SMS', selected: false },
+      ],
+      decision: 'opt-1',
+    };
+    const out = formatNodeForContext(node);
+    expect(out).toContain('id: q-1');
+    expect(out).toContain('type: question');
+    expect(out).toContain('* メールリンク');
+    expect(out).toContain('- 電話SMS');
+    expect(out).toContain('decision: opt-1');
+  });
+
+  it('formatNodeForContext: coderef の filePath/startLine などを含む', () => {
+    const node: Node = {
+      id: 'code-1',
+      type: 'coderef',
+      x: 0,
+      y: 0,
+      title: 'auth/invite.ts',
+      body: '',
+      codebaseId: 'main',
+      filePath: 'src/auth/invite.ts',
+      startLine: 12,
+      endLine: 30,
+      summary: 'invite token 発行',
+    };
+    const out = formatNodeForContext(node);
+    expect(out).toContain('filePath: src/auth/invite.ts');
+    expect(out).toContain('startLine: 12');
+    expect(out).toContain('endLine: 30');
+    expect(out).toContain('summary: invite token 発行');
+  });
+
+  it('buildChatPrompt: 履歴 + context + current の順序で並ぶ', () => {
+    const history = [
+      {
+        id: 'm1',
+        role: 'user' as const,
+        blocks: [{ type: 'text' as const, text: '過去質問' }],
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'm2',
+        role: 'user' as const,
+        blocks: [{ type: 'text' as const, text: '今回の質問' }],
+        createdAt: '2026-01-01T00:01:00Z',
+      },
+    ];
+    const ctx: Node[] = [{ id: 'r-1', type: 'requirement', x: 0, y: 0, title: 'R1', body: '本文' }];
+    const out = buildChatPrompt(history, ctx);
+    const histIdx = out.indexOf('<conversation_history>');
+    const ctxIdx = out.indexOf('<context_nodes>');
+    const curIdx = out.indexOf('<current_user_message>');
+    expect(histIdx).toBeGreaterThanOrEqual(0);
+    expect(ctxIdx).toBeGreaterThan(histIdx);
+    expect(curIdx).toBeGreaterThan(ctxIdx);
+    // current_user_message の中身は最後の user message。
+    expect(out.slice(curIdx)).toContain('今回の質問');
+    expect(out.slice(curIdx)).not.toContain('過去質問');
   });
 });

--- a/packages/ai-engine/src/chat-runner.ts
+++ b/packages/ai-engine/src/chat-runner.ts
@@ -103,7 +103,19 @@ export class ChatRunner {
     await chatStore.appendMessage(threadId, userMsg);
     yield { type: 'chat_user_message_appended', messageId: userMsgId };
 
-    // 2. 空の assistant message を append (後続の tool_use 即時永続化の親として必要)
+    // 2. prompt を先に組む。user message 追加直後の履歴 (末尾が user) をスナップショットし、
+    //    buildChatPrompt が <current_user_message> を末尾の user message として正しく抽出できる状態で呼ぶ。
+    //    これは「<context_nodes> は今ターンの user 入力より前に置く」契約 (issue #11) を守るため必須。
+    //    後続で空 assistant を append すると履歴末尾が assistant になってしまい、buildChatPrompt の
+    //    `last?.role === 'user'` 判定が false に倒れる (= context_nodes が user 入力の後ろに並ぶバグ) ので、
+    //    必ずこの順で snapshot → prompt 組立 → 空 assistant append の順を守る。
+    const threadWithUser = await chatStore.getChat(threadId);
+    const contextNodes = await loadContextNodes(projectStore, contextNodeIds);
+    const prompt = buildChatPrompt(threadWithUser?.messages ?? [], contextNodes);
+    const systemPrompt = buildChatSystemPrompt();
+
+    // 3. 空の assistant message を append (後続の tool_use 即時永続化の親として必要)
+    //    prompt スナップショット後に行うことで、上記 buildChatPrompt の前提が崩れないようにする。
     const assistantMsgId = newChatMessageId();
     await chatStore.appendMessage(threadId, {
       id: assistantMsgId,
@@ -112,12 +124,6 @@ export class ChatRunner {
       createdAt: new Date().toISOString(),
     });
     yield { type: 'chat_assistant_message_started', messageId: assistantMsgId };
-
-    // 3. prompt / system prompt を組む (user msg 追加後の履歴込み)
-    const threadWithUser = await chatStore.getChat(threadId);
-    const contextNodes = await loadContextNodes(projectStore, contextNodeIds);
-    const prompt = buildChatPrompt(threadWithUser?.messages ?? [], contextNodes);
-    const systemPrompt = buildChatSystemPrompt();
 
     // 4. MCP 経由で呼ばれる tool ハンドラ内で invokeInterceptedTool を回す。
     //    MCP handler は SDK query を block するので、イベント emit は AsyncQueue 経由に分離する。
@@ -526,8 +532,11 @@ export function formatNodeForContext(node: Node): string {
     if (node.summary) lines.push(`summary: ${node.summary}`);
     if (node.impact) lines.push(`impact: ${node.impact}`);
   } else if (node.type === 'proposal') {
+    // 未採用の AI 提案であることを AI 側に明示する。
+    // sourceAgentId は AI にとって意味の無い内部属性なので渡さない (codex セカンドオピニオン #16)。
+    // adoptAs は「採用時にどの正規 type に昇格するか」のヒントとして残す (ADR-0005)。
+    lines.push('note: このノードは未採用の AI 提案です (人間の採用操作で正規ノードに昇格)');
     if (node.adoptAs) lines.push(`adoptAs: ${node.adoptAs}`);
-    if (node.sourceAgentId) lines.push(`sourceAgentId: ${node.sourceAgentId}`);
   }
   return lines.join('\n');
 }

--- a/packages/ai-engine/src/chat-runner.ts
+++ b/packages/ai-engine/src/chat-runner.ts
@@ -1,5 +1,11 @@
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
-import { type ChatBlock, type ChatMessage, newChatMessageId, newToolUseId } from '@tally/core';
+import {
+  type ChatBlock,
+  type ChatMessage,
+  type Node,
+  newChatMessageId,
+  newToolUseId,
+} from '@tally/core';
 import type { ChatStore, ProjectStore } from '@tally/storage';
 
 import type { SdkLike } from './agent-runner';
@@ -73,8 +79,12 @@ export class ChatRunner {
   // 3) MCP サーバを組み立てて SDK に渡し、assistant stream を iterate
   // 4) text block は buffer + delta emit。tool_use は MCP ハンドラ内で承認 intercept される。
   // 5) turn 末に text blocks を assistant message 先頭に統合
-  async *runUserTurn(userText: string): AsyncGenerator<ChatEvent> {
-    const { sdk, chatStore, projectDir, threadId } = this.deps;
+  //
+  // contextNodeIds: ユーザーが「@メンション」で添付したノード ID 配列 (issue #11)。
+  // ProjectStore から該当ノードを引いて prompt の <context_nodes> ブロックに埋め込む。
+  // 不在 ID は無視 (削除済みノード等)。永続化はせず、毎ターンの prompt prefix としてのみ使う。
+  async *runUserTurn(userText: string, contextNodeIds: string[] = []): AsyncGenerator<ChatEvent> {
+    const { sdk, chatStore, projectStore, projectDir, threadId } = this.deps;
 
     const thread = await chatStore.getChat(threadId);
     if (!thread) {
@@ -105,7 +115,8 @@ export class ChatRunner {
 
     // 3. prompt / system prompt を組む (user msg 追加後の履歴込み)
     const threadWithUser = await chatStore.getChat(threadId);
-    const prompt = buildChatPrompt(threadWithUser?.messages ?? []);
+    const contextNodes = await loadContextNodes(projectStore, contextNodeIds);
+    const prompt = buildChatPrompt(threadWithUser?.messages ?? [], contextNodes);
     const systemPrompt = buildChatSystemPrompt();
 
     // 4. MCP 経由で呼ばれる tool ハンドラ内で invokeInterceptedTool を回す。
@@ -448,13 +459,87 @@ function buildChatSystemPrompt(): string {
     '- create_node / create_edge は必ずユーザー承認を経る (サーバ側で承認 UI を挟む)。',
     '- 迷ったら質問する。勝手に決めない。',
     '- 既存ノード把握したい時は list_by_type / find_related を使う (承認不要)。',
+    '',
+    'コンテキストノード (issue #11):',
+    '- prompt 内の <context_nodes> はユーザーが明示的に「このノードについて話したい」と添付したノード。',
+    '- 深掘り・分割・方針変更の依頼は、その文脈ノードの id / type / title / body を踏まえて応答する。',
+    '- ノードの「更新」「削除」は AI が直接行えない。代替の proposal を新たに create_node し、',
+    '  ユーザーが採用するかを判断する設計 (ADR-0005)。',
   ].join('\n');
+}
+
+// ProjectStore から context node を引いて、存在するものだけ返す。
+// 順序は入力配列に従う。重複 ID は最初の 1 件のみ残す。
+async function loadContextNodes(store: ProjectStore, ids: readonly string[]): Promise<Node[]> {
+  if (ids.length === 0) return [];
+  const seen = new Set<string>();
+  const out: Node[] = [];
+  for (const id of ids) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const node = await store.getNode(id);
+    if (node) out.push(node);
+  }
+  return out;
+}
+
+// Node を AI 向けにテキスト表現する。冗長な座標 (x/y) は省き、
+// 思考に効く属性 (id/type/title/body と型固有の補助) のみを並べる。
+// JSON.stringify は読みづらいので key: value の素朴な行で並べる。
+export function formatNodeForContext(node: Node): string {
+  const lines: string[] = [];
+  lines.push(`id: ${node.id}`);
+  lines.push(`type: ${node.type}`);
+  if (node.title) lines.push(`title: ${node.title}`);
+  if (node.body) lines.push(`body: ${node.body}`);
+  if (node.type === 'requirement') {
+    if (node.kind) lines.push(`kind: ${node.kind}`);
+    if (node.priority) lines.push(`priority: ${node.priority}`);
+    if (node.qualityCategory) lines.push(`qualityCategory: ${node.qualityCategory}`);
+  } else if (node.type === 'userstory') {
+    if (node.points) lines.push(`points: ${node.points}`);
+    if (node.acceptanceCriteria && node.acceptanceCriteria.length > 0) {
+      lines.push('acceptanceCriteria:');
+      for (const ac of node.acceptanceCriteria) {
+        lines.push(`  - [${ac.done ? 'x' : ' '}] ${ac.text}`);
+      }
+    }
+    if (node.tasks && node.tasks.length > 0) {
+      lines.push('tasks:');
+      for (const t of node.tasks) {
+        lines.push(`  - [${t.done ? 'x' : ' '}] ${t.text}`);
+      }
+    }
+  } else if (node.type === 'question') {
+    if (node.options && node.options.length > 0) {
+      lines.push('options:');
+      for (const o of node.options) {
+        const mark = o.selected ? '*' : '-';
+        lines.push(`  ${mark} ${o.text} (id=${o.id})`);
+      }
+    }
+    if (node.decision) lines.push(`decision: ${node.decision}`);
+  } else if (node.type === 'coderef') {
+    if (node.filePath) lines.push(`filePath: ${node.filePath}`);
+    if (typeof node.startLine === 'number') lines.push(`startLine: ${node.startLine}`);
+    if (typeof node.endLine === 'number') lines.push(`endLine: ${node.endLine}`);
+    if (node.summary) lines.push(`summary: ${node.summary}`);
+    if (node.impact) lines.push(`impact: ${node.impact}`);
+  } else if (node.type === 'proposal') {
+    if (node.adoptAs) lines.push(`adoptAs: ${node.adoptAs}`);
+    if (node.sourceAgentId) lines.push(`sourceAgentId: ${node.sourceAgentId}`);
+  }
+  return lines.join('\n');
 }
 
 // チャット履歴を単一 prompt にエンコードする。
 // tool_use / tool_result は冗長なので省き、text block だけを role 付きで並べる。
 // 最後の user message は current として別タグに出し、モデルの「今答えるべきもの」を明示する。
-function buildChatPrompt(messages: ChatMessage[]): string {
+//
+// contextNodes: 今ターンで参照するコンテキストノード (issue #11)。
+// 履歴より下、current_user_message より上に <context_nodes> として埋め込む。
+// 履歴に積まないのは「ターンごとに添付し直しできる軽量な参照」という UX 設計のため。
+export function buildChatPrompt(messages: ChatMessage[], contextNodes: Node[] = []): string {
   const lines: string[] = [];
   const last = messages[messages.length - 1];
   const past = last?.role === 'user' ? messages.slice(0, -1) : messages;
@@ -472,6 +557,16 @@ function buildChatPrompt(messages: ChatMessage[]): string {
       }
     }
     lines.push('</conversation_history>');
+  }
+
+  if (contextNodes.length > 0) {
+    lines.push('<context_nodes>');
+    for (const node of contextNodes) {
+      lines.push('<node>');
+      lines.push(formatNodeForContext(node));
+      lines.push('</node>');
+    }
+    lines.push('</context_nodes>');
   }
 
   if (last && last.role === 'user') {

--- a/packages/ai-engine/src/server.ts
+++ b/packages/ai-engine/src/server.ts
@@ -24,12 +24,17 @@ const ChatOpenSchema = z.object({
   threadId: z.string().min(1),
 });
 
+// contextNodeIds の最大件数。20 件は UI 操作上現実的な上限であり、prompt 肥大化と
+// 悪意ある大量送信の両方を抑止する (codex セカンドオピニオン #16)。
+const MAX_CHAT_CONTEXT_NODES = 20;
+
 const ChatUserMessageSchema = z.object({
   type: z.literal('user_message'),
   text: z.string().min(1),
   // issue #11: ユーザーが「@メンション」で添付したノード ID 群。
   // 省略時は空配列扱い。runner 側で存在しないものは無視する。
-  contextNodeIds: z.array(z.string().min(1)).optional(),
+  // 上限超過は zod エラー (= bad_request) としてクライアントに返す。
+  contextNodeIds: z.array(z.string().min(1)).max(MAX_CHAT_CONTEXT_NODES).optional(),
 });
 
 const ChatApproveToolSchema = z.object({

--- a/packages/ai-engine/src/server.ts
+++ b/packages/ai-engine/src/server.ts
@@ -27,6 +27,9 @@ const ChatOpenSchema = z.object({
 const ChatUserMessageSchema = z.object({
   type: z.literal('user_message'),
   text: z.string().min(1),
+  // issue #11: ユーザーが「@メンション」で添付したノード ID 群。
+  // 省略時は空配列扱い。runner 側で存在しないものは無視する。
+  contextNodeIds: z.array(z.string().min(1)).optional(),
 });
 
 const ChatApproveToolSchema = z.object({
@@ -206,7 +209,10 @@ function handleChatConnection(ws: WebSocket, sdk: SdkLike): void {
         return;
       }
       try {
-        for await (const evt of runner.runUserTurn(result.data.text)) {
+        for await (const evt of runner.runUserTurn(
+          result.data.text,
+          result.data.contextNodeIds ?? [],
+        )) {
           send(evt);
         }
       } catch (err) {

--- a/packages/frontend/e2e/chat-node-context.spec.ts
+++ b/packages/frontend/e2e/chat-node-context.spec.ts
@@ -85,7 +85,7 @@ test.describe('Chat コンテキストノード操作', () => {
     const picker = page.getByRole('dialog', { name: 'コンテキストに追加するノードを選択' });
     await expect(picker).toBeVisible();
     // ピッカー内のボタンで該当ノードを 1 件 add。文字列短縮(36文字以下) のため title 完全一致で取れる。
-    await picker.getByRole('button', { name: new RegExp(TARGET_TITLE_PICKER) }).click();
+    await picker.getByRole('button', { name: TARGET_TITLE_PICKER }).click();
 
     await expect(bar.getByTestId('chat-context-chip')).toHaveCount(2);
   });
@@ -99,7 +99,7 @@ test.describe('Chat コンテキストノード操作', () => {
     await page.getByRole('button', { name: '選択中のノードを添付' }).click();
     await page.getByRole('button', { name: 'コンテキストにノードを追加' }).click();
     const picker = page.getByRole('dialog', { name: 'コンテキストに追加するノードを選択' });
-    await picker.getByRole('button', { name: new RegExp(TARGET_TITLE_PICKER) }).click();
+    await picker.getByRole('button', { name: TARGET_TITLE_PICKER }).click();
 
     const bar = page.getByTestId('chat-context-bar');
     await expect(bar.getByTestId('chat-context-chip')).toHaveCount(2);

--- a/packages/frontend/e2e/chat-node-context.spec.ts
+++ b/packages/frontend/e2e/chat-node-context.spec.ts
@@ -1,0 +1,129 @@
+import { expect, type Page, test } from '@playwright/test';
+
+// Issue #11 / PR #16: Chat タブにノードをコンテキストとして添付できるバー (ChatContextBar) の E2E。
+// ai-engine は起動しないため、WebSocket 越しの実 AI 応答は検証対象外。
+// 検証範囲は ChatContextBar の UI / store 操作のみ:
+//   - 添付チップの表示
+//   - キャンバスで選択したノードを「選択中のノードを添付」ボタンで追加
+//   - ピッカーからの追加
+//   - 個別 chip の x 解除
+//   - 「すべて解除」(全解除) で空に
+// チャット送信 (sendChatMessage) は ai-engine 必須なので、未起動状態での送信ボタン disabled を最後に確認。
+
+const TARGET_TITLE_SELECT = '権限レベルの柔軟設定';
+const TARGET_TITLE_PICKER = 'チーム招待機能';
+
+async function openSampleProject(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.getByRole('link', { name: /TaskFlow 招待機能追加/ }).click();
+  await page.locator('.react-flow__node').first().waitFor({ state: 'visible' });
+}
+
+// 右サイドバーの Chat タブを開き、新規スレッドを作る。
+// chat-context-bar testid が現れるまで待つ (WS 接続失敗は許容)。
+async function openChatTabWithNewThread(page: Page): Promise<void> {
+  await page.getByRole('tab', { name: 'Chat' }).click();
+  await page.getByRole('button', { name: '+ 新規' }).click();
+  await page.getByTestId('chat-context-bar').waitFor({ state: 'visible' });
+}
+
+function nodeByTitle(page: Page, title: string) {
+  return page.locator('.react-flow__node').filter({ hasText: title }).first();
+}
+
+// 指定タイトルのノードをクリックして selected: { kind: 'node', id } 状態にする。
+// React Flow の onNodeClick が発火する程度の単発クリックで十分。
+async function selectNodeOnCanvas(page: Page, title: string): Promise<void> {
+  const node = nodeByTitle(page, title);
+  await node.click({ position: { x: 10, y: 10 } });
+}
+
+test.describe('Chat コンテキストノード操作', () => {
+  test('Chat タブを開くと ChatContextBar が表示され初期は未添付', async ({ page }) => {
+    await openSampleProject(page);
+    await openChatTabWithNewThread(page);
+
+    const bar = page.getByTestId('chat-context-bar');
+    await expect(bar).toBeVisible();
+    // 初期は chip が 0 件で「未添付」表記が出る。
+    await expect(bar.getByTestId('chat-context-chip')).toHaveCount(0);
+    await expect(bar.getByText('未添付')).toBeVisible();
+    // 添付済みが 0 のときは「すべて解除」ボタンは出ない。
+    await expect(page.getByRole('button', { name: 'コンテキストをすべて解除' })).toHaveCount(0);
+  });
+
+  test('キャンバスで選択中のノードをショートカットで添付できる', async ({ page }) => {
+    await openSampleProject(page);
+    await openChatTabWithNewThread(page);
+
+    // キャンバスのノードをクリックして選択 (Chat タブを開いたままでも react-flow は触れる)。
+    await selectNodeOnCanvas(page, TARGET_TITLE_SELECT);
+
+    // 「選択中のノードを添付」ボタンが出る。クリックで chip 化。
+    const addSelectedBtn = page.getByRole('button', { name: '選択中のノードを添付' });
+    await expect(addSelectedBtn).toBeVisible();
+    await addSelectedBtn.click();
+
+    const bar = page.getByTestId('chat-context-bar');
+    await expect(bar.getByTestId('chat-context-chip')).toHaveCount(1);
+    // 同じノードを再度添付しようとしてもボタン自体が消える (canAttachSelected = false)。
+    await expect(addSelectedBtn).toHaveCount(0);
+  });
+
+  test('ピッカーから別のノードを追加できる (合計 2 件)', async ({ page }) => {
+    await openSampleProject(page);
+    await openChatTabWithNewThread(page);
+
+    // 1 件目: ショートカットで追加
+    await selectNodeOnCanvas(page, TARGET_TITLE_SELECT);
+    await page.getByRole('button', { name: '選択中のノードを添付' }).click();
+    const bar = page.getByTestId('chat-context-bar');
+    await expect(bar.getByTestId('chat-context-chip')).toHaveCount(1);
+
+    // 2 件目: ピッカーから追加
+    await page.getByRole('button', { name: 'コンテキストにノードを追加' }).click();
+    const picker = page.getByRole('dialog', { name: 'コンテキストに追加するノードを選択' });
+    await expect(picker).toBeVisible();
+    // ピッカー内のボタンで該当ノードを 1 件 add。文字列短縮(36文字以下) のため title 完全一致で取れる。
+    await picker.getByRole('button', { name: new RegExp(TARGET_TITLE_PICKER) }).click();
+
+    await expect(bar.getByTestId('chat-context-chip')).toHaveCount(2);
+  });
+
+  test('chip の x で 1 件削除し、「すべて解除」で空に戻せる', async ({ page }) => {
+    await openSampleProject(page);
+    await openChatTabWithNewThread(page);
+
+    // 2 件添付して下準備。
+    await selectNodeOnCanvas(page, TARGET_TITLE_SELECT);
+    await page.getByRole('button', { name: '選択中のノードを添付' }).click();
+    await page.getByRole('button', { name: 'コンテキストにノードを追加' }).click();
+    const picker = page.getByRole('dialog', { name: 'コンテキストに追加するノードを選択' });
+    await picker.getByRole('button', { name: new RegExp(TARGET_TITLE_PICKER) }).click();
+
+    const bar = page.getByTestId('chat-context-bar');
+    await expect(bar.getByTestId('chat-context-chip')).toHaveCount(2);
+
+    // 1 件目の chip にある「× 解除」ボタン (aria-label に「を解除」を含む) を 1 つ押す。
+    const removeBtns = bar.getByRole('button', { name: /を解除$/ });
+    await removeBtns.first().click();
+    await expect(bar.getByTestId('chat-context-chip')).toHaveCount(1);
+
+    // 「すべて解除」で残り 1 件も消す。
+    await page.getByRole('button', { name: 'コンテキストをすべて解除' }).click();
+    await expect(bar.getByTestId('chat-context-chip')).toHaveCount(0);
+    await expect(bar.getByText('未添付')).toBeVisible();
+  });
+
+  test('未入力時は送信ボタンが disabled (ai-engine 未起動でも UI で確認できる)', async ({
+    page,
+  }) => {
+    await openSampleProject(page);
+    await openChatTabWithNewThread(page);
+
+    // 何も入力していない状態 (text.trim().length === 0) では送信ボタンは disabled。
+    // ai-engine が無くても WebSocket の有無に関係なく UI 単独で確認できる。
+    const sendBtn = page.getByRole('button', { name: '送信' });
+    await expect(sendBtn).toBeDisabled();
+  });
+});

--- a/packages/frontend/src/components/chat/chat-context-bar.test.tsx
+++ b/packages/frontend/src/components/chat/chat-context-bar.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useCanvasStore } from '@/lib/store';
+
+import { ChatContextBar } from './chat-context-bar';
+
+// issue #11: コンテキストバーは store の chatContextNodeIds を可視化し、
+// add/remove ボタンで操作する。最低限の挙動を担保する。
+describe('ChatContextBar', () => {
+  beforeEach(() => {
+    useCanvasStore.getState().reset();
+    // ノード 2 件を仕込む
+    useCanvasStore.setState({
+      nodes: {
+        'req-a': { id: 'req-a', type: 'requirement', x: 0, y: 0, title: 'A', body: '' },
+        'uc-1': { id: 'uc-1', type: 'usecase', x: 0, y: 0, title: 'UC1', body: '' },
+      },
+    } as never);
+  });
+
+  it('未添付なら「未添付」が出る', () => {
+    render(<ChatContextBar />);
+    expect(screen.getByText('未添付')).toBeDefined();
+  });
+
+  it('「+ ノードを追加」でピッカー開閉、ノードクリックで添付', () => {
+    render(<ChatContextBar />);
+    const openBtn = screen.getByRole('button', { name: 'コンテキストにノードを追加' });
+    fireEvent.click(openBtn);
+    // 要求ノード A が候補に出る
+    const item = screen.getByText(/^A/);
+    fireEvent.click(item);
+    expect(useCanvasStore.getState().chatContextNodeIds).toEqual(['req-a']);
+  });
+
+  it('chip の × で個別解除できる', () => {
+    useCanvasStore.getState().addChatContextNode('req-a');
+    render(<ChatContextBar />);
+    const removeBtn = screen.getByRole('button', { name: /要求「A」を解除/ });
+    fireEvent.click(removeBtn);
+    expect(useCanvasStore.getState().chatContextNodeIds).toEqual([]);
+  });
+
+  it('「すべて解除」で chatContextNodeIds が空になる', () => {
+    useCanvasStore.getState().addChatContextNode('req-a');
+    useCanvasStore.getState().addChatContextNode('uc-1');
+    render(<ChatContextBar />);
+    const clearBtn = screen.getByRole('button', { name: /コンテキストをすべて解除/ });
+    fireEvent.click(clearBtn);
+    expect(useCanvasStore.getState().chatContextNodeIds).toEqual([]);
+  });
+
+  it('選択中ノードが未添付ならショートカットボタンが出る、押すと add される', () => {
+    useCanvasStore.getState().select({ kind: 'node', id: 'uc-1' });
+    render(<ChatContextBar />);
+    const btn = screen.getByRole('button', { name: '選択中のノードを添付' });
+    fireEvent.click(btn);
+    expect(useCanvasStore.getState().chatContextNodeIds).toEqual(['uc-1']);
+  });
+});

--- a/packages/frontend/src/components/chat/chat-context-bar.tsx
+++ b/packages/frontend/src/components/chat/chat-context-bar.tsx
@@ -29,7 +29,7 @@ export function ChatContextBar() {
   const canAttachSelected = selectedNodeId != null && !ids.includes(selectedNodeId);
 
   return (
-    <div style={WRAP_STYLE}>
+    <div style={WRAP_STYLE} data-testid="chat-context-bar">
       <div style={ROW_STYLE}>
         <span style={LABEL_STYLE}>コンテキスト</span>
         {attached.map((n) => (
@@ -90,6 +90,7 @@ function ChatContextChip({ node, onRemove }: ChipProps) {
         borderColor: meta.accent,
       }}
       title={`${meta.label}: ${label}`}
+      data-testid="chat-context-chip"
     >
       <span style={{ color: meta.color, fontSize: 10 }}>{meta.icon}</span>
       <span>{truncated}</span>

--- a/packages/frontend/src/components/chat/chat-context-bar.tsx
+++ b/packages/frontend/src/components/chat/chat-context-bar.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { NODE_META, type Node, type NodeType } from '@tally/core';
+import { useState } from 'react';
+
+import { useCanvasStore } from '@/lib/store';
+
+// issue #11: Chat に「@メンション」のように添付するノードを操作するバー。
+// ChatInput の上に並ぶ。役割は 3 つ:
+//  1) 添付済みノードを chip として並べ、x で個別解除
+//  2) 「+ ノードを追加」ボタンでピッカーを開き、キャンバスのノードを type 別にまとめて選ぶ
+//  3) 選択中ノード (canvas で 1 つ選んでいる時) を一発で添付するショートカット
+//
+// 永続化はしない (store 側で管理、スレッド切替で自動クリア)。
+export function ChatContextBar() {
+  const nodes = useCanvasStore((s) => s.nodes);
+  const selected = useCanvasStore((s) => s.selected);
+  const ids = useCanvasStore((s) => s.chatContextNodeIds);
+  const addCtx = useCanvasStore((s) => s.addChatContextNode);
+  const removeCtx = useCanvasStore((s) => s.removeChatContextNode);
+  const clearCtx = useCanvasStore((s) => s.clearChatContext);
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  // 削除済みノードを参照している場合は表示から除外する (送信時にも store でフィルタ済み)。
+  const attached = ids.map((id) => nodes[id]).filter((n): n is Node => Boolean(n));
+
+  const selectedNodeId = selected?.kind === 'node' ? selected.id : null;
+  const canAttachSelected = selectedNodeId != null && !ids.includes(selectedNodeId);
+
+  return (
+    <div style={WRAP_STYLE}>
+      <div style={ROW_STYLE}>
+        <span style={LABEL_STYLE}>コンテキスト</span>
+        {attached.map((n) => (
+          <ChatContextChip key={n.id} node={n} onRemove={() => removeCtx(n.id)} />
+        ))}
+        {attached.length === 0 && <span style={EMPTY_STYLE}>未添付</span>}
+      </div>
+      <div style={ROW_STYLE}>
+        <button
+          type="button"
+          style={BUTTON_STYLE}
+          onClick={() => setPickerOpen((v) => !v)}
+          aria-expanded={pickerOpen}
+          aria-label="コンテキストにノードを追加"
+        >
+          {pickerOpen ? '× 閉じる' : '+ ノードを追加'}
+        </button>
+        {canAttachSelected && selectedNodeId && (
+          <button
+            type="button"
+            style={BUTTON_STYLE}
+            onClick={() => addCtx(selectedNodeId)}
+            aria-label="選択中のノードを添付"
+          >
+            ＠選択中ノードを追加
+          </button>
+        )}
+        {attached.length > 0 && (
+          <button
+            type="button"
+            style={SECONDARY_BUTTON_STYLE}
+            onClick={() => clearCtx()}
+            aria-label="コンテキストをすべて解除"
+          >
+            すべて解除
+          </button>
+        )}
+      </div>
+      {pickerOpen && <ChatContextPicker onClose={() => setPickerOpen(false)} />}
+    </div>
+  );
+}
+
+interface ChipProps {
+  node: Node;
+  onRemove: () => void;
+}
+
+// 1 個のコンテキストノードを示す chip。type の色をボーダーに反映する。
+function ChatContextChip({ node, onRemove }: ChipProps) {
+  const meta = NODE_META[node.type];
+  const label = node.title.trim().length > 0 ? node.title : '(無題)';
+  const truncated = label.length > 24 ? `${label.slice(0, 24)}…` : label;
+  return (
+    <span
+      style={{
+        ...CHIP_STYLE,
+        borderColor: meta.accent,
+      }}
+      title={`${meta.label}: ${label}`}
+    >
+      <span style={{ color: meta.color, fontSize: 10 }}>{meta.icon}</span>
+      <span>{truncated}</span>
+      <button
+        type="button"
+        style={CHIP_REMOVE_STYLE}
+        onClick={onRemove}
+        aria-label={`${meta.label}「${label}」を解除`}
+      >
+        ×
+      </button>
+    </span>
+  );
+}
+
+interface PickerProps {
+  onClose: () => void;
+}
+
+// type 別グルーピングのピッカー。表示順は NODE_TYPES の宣言順 (proposal は最後)。
+function ChatContextPicker({ onClose }: PickerProps) {
+  const nodes = useCanvasStore((s) => s.nodes);
+  const ids = useCanvasStore((s) => s.chatContextNodeIds);
+  const addCtx = useCanvasStore((s) => s.addChatContextNode);
+
+  const all = Object.values(nodes);
+  const groupedByType = new Map<NodeType, Node[]>();
+  for (const n of all) {
+    const arr = groupedByType.get(n.type) ?? [];
+    arr.push(n);
+    groupedByType.set(n.type, arr);
+  }
+  // NODE_META のキー順で並べる (NODE_TYPES と一致)。
+  const orderedTypes = Object.keys(NODE_META) as NodeType[];
+
+  if (all.length === 0) {
+    return (
+      <div style={PICKER_STYLE}>
+        <p style={PICKER_EMPTY_STYLE}>キャンバスにノードがありません。</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={PICKER_STYLE} role="dialog" aria-label="コンテキストに追加するノードを選択">
+      {orderedTypes.map((type) => {
+        const items = groupedByType.get(type);
+        if (!items || items.length === 0) return null;
+        const meta = NODE_META[type];
+        return (
+          <div key={type} style={PICKER_GROUP_STYLE}>
+            <div style={{ ...PICKER_GROUP_HEADER_STYLE, color: meta.color }}>
+              {meta.icon} {meta.label} ({items.length})
+            </div>
+            <div style={PICKER_LIST_STYLE}>
+              {items.map((n) => {
+                const already = ids.includes(n.id);
+                const label = n.title.trim().length > 0 ? n.title : '(無題)';
+                const truncated = label.length > 36 ? `${label.slice(0, 36)}…` : label;
+                return (
+                  <button
+                    key={n.id}
+                    type="button"
+                    disabled={already}
+                    onClick={() => addCtx(n.id)}
+                    style={{
+                      ...PICKER_ITEM_STYLE,
+                      opacity: already ? 0.4 : 1,
+                      cursor: already ? 'default' : 'pointer',
+                    }}
+                    title={label}
+                  >
+                    {truncated} {already ? '(添付済)' : ''}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+      <div style={PICKER_FOOTER_STYLE}>
+        <button type="button" style={SECONDARY_BUTTON_STYLE} onClick={onClose}>
+          閉じる
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---- styles ----
+const WRAP_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: 4,
+  padding: '4px 4px 0 4px',
+};
+const ROW_STYLE = {
+  display: 'flex',
+  flexWrap: 'wrap' as const,
+  alignItems: 'center',
+  gap: 6,
+};
+const LABEL_STYLE = {
+  fontSize: 11,
+  color: '#8b949e',
+  marginRight: 2,
+};
+const EMPTY_STYLE = {
+  fontSize: 11,
+  color: '#6e7681',
+  fontStyle: 'italic' as const,
+};
+const CHIP_STYLE = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  border: '1px solid #30363d',
+  borderRadius: 12,
+  padding: '2px 6px',
+  fontSize: 11,
+  background: '#161b22',
+  color: '#e6edf3',
+  maxWidth: 220,
+};
+const CHIP_REMOVE_STYLE = {
+  background: 'transparent',
+  border: 'none',
+  color: '#8b949e',
+  cursor: 'pointer',
+  fontSize: 12,
+  padding: 0,
+  lineHeight: 1,
+};
+const BUTTON_STYLE = {
+  background: '#21262d',
+  color: '#e6edf3',
+  border: '1px solid #30363d',
+  borderRadius: 6,
+  padding: '2px 8px',
+  fontSize: 11,
+  cursor: 'pointer',
+};
+const SECONDARY_BUTTON_STYLE = {
+  ...BUTTON_STYLE,
+  color: '#8b949e',
+};
+const PICKER_STYLE = {
+  border: '1px solid #30363d',
+  background: '#0d1117',
+  borderRadius: 6,
+  padding: 6,
+  marginTop: 2,
+  maxHeight: 240,
+  overflow: 'auto' as const,
+};
+const PICKER_EMPTY_STYLE = {
+  fontSize: 11,
+  color: '#8b949e',
+  margin: 0,
+  padding: 4,
+};
+const PICKER_GROUP_STYLE = {
+  marginBottom: 6,
+};
+const PICKER_GROUP_HEADER_STYLE = {
+  fontSize: 11,
+  fontWeight: 600 as const,
+  marginBottom: 2,
+};
+const PICKER_LIST_STYLE = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: 2,
+};
+const PICKER_ITEM_STYLE = {
+  background: 'transparent',
+  border: '1px solid transparent',
+  color: '#e6edf3',
+  textAlign: 'left' as const,
+  fontSize: 11,
+  padding: '2px 6px',
+  borderRadius: 4,
+};
+const PICKER_FOOTER_STYLE = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  marginTop: 4,
+};

--- a/packages/frontend/src/components/chat/chat-context-bar.tsx
+++ b/packages/frontend/src/components/chat/chat-context-bar.tsx
@@ -28,6 +28,11 @@ export function ChatContextBar() {
   const selectedNodeId = selected?.kind === 'node' ? selected.id : null;
   const canAttachSelected = selectedNodeId != null && !ids.includes(selectedNodeId);
 
+  // pickerOpen の状態に応じてトグルボタンの aria-label を切り替え、SR でも開閉が伝わるようにする。
+  const pickerToggleLabel = pickerOpen
+    ? 'コンテキスト追加ピッカーを閉じる'
+    : 'コンテキストにノードを追加';
+
   return (
     <div style={WRAP_STYLE} data-testid="chat-context-bar">
       <div style={ROW_STYLE}>
@@ -43,7 +48,7 @@ export function ChatContextBar() {
           style={BUTTON_STYLE}
           onClick={() => setPickerOpen((v) => !v)}
           aria-expanded={pickerOpen}
-          aria-label="コンテキストにノードを追加"
+          aria-label={pickerToggleLabel}
         >
           {pickerOpen ? '× 閉じる' : '+ ノードを追加'}
         </button>
@@ -116,29 +121,33 @@ function ChatContextPicker({ onClose }: PickerProps) {
   const ids = useCanvasStore((s) => s.chatContextNodeIds);
   const addCtx = useCanvasStore((s) => s.addChatContextNode);
 
-  const all = Object.values(nodes);
-  const groupedByType = new Map<NodeType, Node[]>();
-  for (const n of all) {
-    const arr = groupedByType.get(n.type) ?? [];
-    arr.push(n);
-    groupedByType.set(n.type, arr);
-  }
-  // NODE_META のキー順で並べる (NODE_TYPES と一致)。
+  // NODE_META のキー順 (= 宣言順) で 1 パスに直接 groups を組む。
+  // 2 段階 (Map 構築 → 再走査) を避け、空グループはここで除外する。
   const orderedTypes = Object.keys(NODE_META) as NodeType[];
+  const groups = orderedTypes
+    .map((type) => ({
+      type,
+      items: Object.values(nodes).filter((n) => n.type === type),
+    }))
+    .filter((g) => g.items.length > 0);
+  const isEmpty = groups.length === 0;
 
-  if (all.length === 0) {
+  if (isEmpty) {
     return (
-      <div style={PICKER_STYLE}>
+      <div style={PICKER_STYLE} role="dialog" aria-label="コンテキストに追加するノードを選択">
         <p style={PICKER_EMPTY_STYLE}>キャンバスにノードがありません。</p>
+        <div style={PICKER_FOOTER_STYLE}>
+          <button type="button" style={SECONDARY_BUTTON_STYLE} onClick={onClose}>
+            閉じる
+          </button>
+        </div>
       </div>
     );
   }
 
   return (
     <div style={PICKER_STYLE} role="dialog" aria-label="コンテキストに追加するノードを選択">
-      {orderedTypes.map((type) => {
-        const items = groupedByType.get(type);
-        if (!items || items.length === 0) return null;
+      {groups.map(({ type, items }) => {
         const meta = NODE_META[type];
         return (
           <div key={type} style={PICKER_GROUP_STYLE}>

--- a/packages/frontend/src/components/chat/chat-tab.tsx
+++ b/packages/frontend/src/components/chat/chat-tab.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 
 import { useCanvasStore } from '@/lib/store';
 
+import { ChatContextBar } from './chat-context-bar';
 import { ChatInput } from './chat-input';
 import { ChatMessages } from './chat-messages';
 import { ChatThreadList } from './chat-thread-list';
@@ -38,6 +39,7 @@ export function ChatTab() {
           <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
             <ChatMessages />
           </div>
+          <ChatContextBar />
           <ChatInput />
         </>
       ) : (

--- a/packages/frontend/src/lib/store.test.ts
+++ b/packages/frontend/src/lib/store.test.ts
@@ -726,4 +726,104 @@ describe('useCanvasStore', () => {
       expect(approveSpy).toHaveBeenCalledWith('tool-1', true);
     });
   });
+
+  // issue #11: チャットコンテキストノード添付の操作と sendChatMessage への伝搬。
+  describe('chat context nodes', () => {
+    it('add/remove/clear で chatContextNodeIds が変化する', () => {
+      const s = useCanvasStore.getState();
+      s.addChatContextNode('req-a');
+      expect(useCanvasStore.getState().chatContextNodeIds).toEqual(['req-a']);
+      // 重複追加は no-op
+      useCanvasStore.getState().addChatContextNode('req-a');
+      expect(useCanvasStore.getState().chatContextNodeIds).toEqual(['req-a']);
+      useCanvasStore.getState().addChatContextNode('req-b');
+      expect(useCanvasStore.getState().chatContextNodeIds).toEqual(['req-a', 'req-b']);
+      useCanvasStore.getState().removeChatContextNode('req-a');
+      expect(useCanvasStore.getState().chatContextNodeIds).toEqual(['req-b']);
+      useCanvasStore.getState().clearChatContext();
+      expect(useCanvasStore.getState().chatContextNodeIds).toEqual([]);
+    });
+
+    it('sendChatMessage は chatContextNodeIds を 2 引数目に渡す (削除済み id は除外)', async () => {
+      const sent: { text: string; ctx: string[] | undefined }[] = [];
+      vi.resetModules();
+      vi.doMock('./ws', () => ({
+        startAgent: vi.fn(),
+        openChat: () => ({
+          events: (async function* () {
+            yield { type: 'chat_opened', threadId: 'chat-1' };
+          })(),
+          sendUserMessage: (text: string, ctx?: string[]) => sent.push({ text, ctx }),
+          approveTool: vi.fn(),
+          close: () => {},
+        }),
+      }));
+      const { useCanvasStore: store } = await import('./store');
+      store.getState().hydrate({
+        id: 'proj-1',
+        name: 't',
+        codebases: [],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        nodes: [
+          { id: 'req-a', type: 'requirement', x: 0, y: 0, title: 'A', body: '' },
+          { id: 'req-b', type: 'requirement', x: 0, y: 0, title: 'B', body: '' },
+        ],
+        edges: [],
+      });
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'chat-1', messages: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+      await store.getState().openChatThread('chat-1');
+      await new Promise((r) => setTimeout(r, 20));
+      // 存在する 2 件 + 削除済み 1 件を仕込む
+      store.getState().addChatContextNode('req-a');
+      store.getState().addChatContextNode('req-b');
+      store.getState().addChatContextNode('req-deleted');
+      await store.getState().sendChatMessage('深掘りして');
+      expect(sent).toHaveLength(1);
+      expect(sent[0]?.text).toBe('深掘りして');
+      // 存在しない req-deleted は除外される
+      expect(sent[0]?.ctx).toEqual(['req-a', 'req-b']);
+    });
+
+    it('スレッド切替時に chatContextNodeIds はリセットされる', async () => {
+      vi.resetModules();
+      vi.doMock('./ws', () => ({
+        startAgent: vi.fn(),
+        openChat: () => ({
+          events: (async function* () {
+            yield { type: 'chat_opened', threadId: 'chat-1' };
+          })(),
+          sendUserMessage: vi.fn(),
+          approveTool: vi.fn(),
+          close: () => {},
+        }),
+      }));
+      const { useCanvasStore: store } = await import('./store');
+      store.getState().hydrate({
+        id: 'proj-1',
+        name: 't',
+        codebases: [],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        nodes: [{ id: 'req-a', type: 'requirement', x: 0, y: 0, title: 'A', body: '' }],
+        edges: [],
+      });
+      store.getState().addChatContextNode('req-a');
+      expect(store.getState().chatContextNodeIds).toEqual(['req-a']);
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'chat-1', messages: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+      await store.getState().openChatThread('chat-1');
+      // openChatThread の中で chatContextNodeIds: [] にリセットされる
+      expect(store.getState().chatContextNodeIds).toEqual([]);
+    });
+  });
 });

--- a/packages/frontend/src/lib/store.ts
+++ b/packages/frontend/src/lib/store.ts
@@ -139,6 +139,11 @@ function byId<T extends { id: string }>(items: T[]): Record<string, T> {
   return out;
 }
 
+// issue #11: チャットコンテキストに添付できるノード数の上限。
+// サーバ側 (packages/ai-engine/src/server.ts の MAX_CHAT_CONTEXT_NODES) と同じ値。
+// クライアント側でも先回りで弾くことで、無駄な WS フレームを送らない & UI の意図を明示する。
+const MAX_CHAT_CONTEXT_NODES = 20;
+
 // Phase 3: 可変ストア。楽観的更新 + 失敗時ロールバックで YAML と同期する。
 export const useCanvasStore = create<CanvasState>((set, get) => {
   // Phase 6: 現在開いているチャットスレッドの WS handle。
@@ -678,9 +683,12 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
 
     // issue #11: チャット添付ノードの操作。
     // add: 重複なら no-op、存在しないノード id でも UI 側でフィルタするので許容。
+    // 上限 (MAX_CHAT_CONTEXT_NODES) を超える場合も no-op。サーバ側でも同じ値で弾くが、
+    // クライアントで先に弾くことで送信前に状態を一致させる。
     addChatContextNode: (nodeId) => {
       const cur = get().chatContextNodeIds;
       if (cur.includes(nodeId)) return;
+      if (cur.length >= MAX_CHAT_CONTEXT_NODES) return;
       set({ chatContextNodeIds: [...cur, nodeId] });
     },
     removeChatContextNode: (nodeId) => {

--- a/packages/frontend/src/lib/store.ts
+++ b/packages/frontend/src/lib/store.ts
@@ -113,6 +113,15 @@ interface CanvasState {
   closeChatThread: () => void;
   sendChatMessage: (text: string) => Promise<void>;
   approveChatTool: (toolUseId: string, approved: boolean) => void;
+
+  // issue #11: チャットに「@メンション」のように添付するノード ID 群。
+  // 順序保持 + 重複排除のため配列で持つ。スレッド切替・close で自動クリア
+  // (永続化はしない / chats/<id>.yaml にも書かない)。
+  chatContextNodeIds: string[];
+  addChatContextNode: (nodeId: string) => void;
+  removeChatContextNode: (nodeId: string) => void;
+  clearChatContext: () => void;
+
   // 現在開いているスレッドを削除する。open 中なら閉じ、一覧からも除去。
   deleteChatThread: (threadId: string) => Promise<void>;
   // プロジェクトのノード/エッジ/チャットを全クリア (project.yaml は維持)。
@@ -331,6 +340,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
     activeChatThreadId: null,
     chatThreadMessages: [],
     chatThreadStreaming: false,
+    chatContextNodeIds: [],
 
     hydrate: (project) => {
       const { nodes, edges, ...meta } = project;
@@ -342,6 +352,8 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
         selected: null,
         // プロジェクト切替時は全ノード折りたたみで開始する (つながり重視の初期表示)。
         expandedNodes: {},
+        // プロジェクト切替時は context もクリア (別プロジェクトのノード id は無効)。
+        chatContextNodeIds: [],
       });
     },
 
@@ -354,6 +366,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
         selected: null,
         expandedNodes: {},
         runningAgent: null,
+        chatContextNodeIds: [],
       }),
 
     select: (target) => set({ selected: target }),
@@ -632,6 +645,8 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
         activeChatThreadId: threadId,
         chatThreadMessages: thread.messages,
         chatThreadStreaming: false,
+        // スレッド切替時は context もリセット (前スレッドの添付を引きずらない)。
+        chatContextNodeIds: [],
       });
       const handle = openChat({ projectId: pid, threadId });
       chatHandle = handle;
@@ -653,11 +668,31 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
         chatHandle.close();
         chatHandle = null;
       }
-      set({ activeChatThreadId: null, chatThreadMessages: [], chatThreadStreaming: false });
+      set({
+        activeChatThreadId: null,
+        chatThreadMessages: [],
+        chatThreadStreaming: false,
+        chatContextNodeIds: [],
+      });
     },
+
+    // issue #11: チャット添付ノードの操作。
+    // add: 重複なら no-op、存在しないノード id でも UI 側でフィルタするので許容。
+    addChatContextNode: (nodeId) => {
+      const cur = get().chatContextNodeIds;
+      if (cur.includes(nodeId)) return;
+      set({ chatContextNodeIds: [...cur, nodeId] });
+    },
+    removeChatContextNode: (nodeId) => {
+      set({ chatContextNodeIds: get().chatContextNodeIds.filter((id) => id !== nodeId) });
+    },
+    clearChatContext: () => set({ chatContextNodeIds: [] }),
 
     // user 入力を WS に送る。楽観的に user メッセージをローカルにも積み、streaming フラグを立てる。
     // サーバ側は chat_user_message_appended で append 完了を通知するが、UI は楽観分で十分。
+    // issue #11: chatContextNodeIds を WS フレームに同梱して AI に渡す。
+    // 送信後はキャンバス側で別ノードを取り上げ直しがち、かつ「同じノードを連続で参照したい」
+    // ケースもあるため、自動クリアはしない。明示的に削除/clear を呼ぶ運用。
     sendChatMessage: async (text) => {
       if (!chatHandle) throw new Error('chat thread is not opened');
       const userMsg: ChatMessage = {
@@ -670,7 +705,10 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
         chatThreadMessages: [...get().chatThreadMessages, userMsg],
         chatThreadStreaming: true,
       });
-      chatHandle.sendUserMessage(text);
+      // 削除済みノード id (キャンバスから消えたもの) はサーバが getNode で弾くが、
+      // クライアント側でも一応フィルタして無駄なペイロードを送らない。
+      const ctxIds = get().chatContextNodeIds.filter((id) => id in get().nodes);
+      chatHandle.sendUserMessage(text, ctxIds);
     },
 
     approveChatTool: (toolUseId, approved) => {
@@ -691,6 +729,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
           activeChatThreadId: null,
           chatThreadMessages: [],
           chatThreadStreaming: false,
+          chatContextNodeIds: [],
         });
       }
       await deleteChatThreadApi(pid, threadId);
@@ -717,6 +756,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => {
         activeChatThreadId: null,
         chatThreadMessages: [],
         chatThreadStreaming: false,
+        chatContextNodeIds: [],
       });
     },
 

--- a/packages/frontend/src/lib/ws.ts
+++ b/packages/frontend/src/lib/ws.ts
@@ -86,9 +86,12 @@ export function startAgent(opts: StartAgentOptions): AgentHandle {
 // ChatHandle: /chat WS 接続のハンドル。events は ChatEvent の AsyncIterable、
 // sendUserMessage / approveTool は client → server 方向のメッセージ送信。
 // close() で WS を閉じる (サーバ側も runner を破棄する)。
+//
+// sendUserMessage の contextNodeIds は issue #11 で追加。空 / 省略時はサーバが
+// 「context 添付なし」として扱う。
 export interface ChatHandle {
   events: AsyncIterable<ChatEvent>;
-  sendUserMessage: (text: string) => void;
+  sendUserMessage: (text: string, contextNodeIds?: string[]) => void;
   approveTool: (toolUseId: string, approved: boolean) => void;
   close: () => void;
 }
@@ -178,7 +181,12 @@ export function openChat(opts: OpenChatOptions): ChatHandle {
 
   return {
     events,
-    sendUserMessage: (text) => sendWhenReady({ type: 'user_message', text }),
+    sendUserMessage: (text, contextNodeIds) =>
+      sendWhenReady({
+        type: 'user_message',
+        text,
+        ...(contextNodeIds && contextNodeIds.length > 0 ? { contextNodeIds } : {}),
+      }),
     approveTool: (toolUseId, approved) =>
       sendWhenReady({ type: 'approve_tool', toolUseId, approved }),
     close: () => ws.close(),

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -25,6 +25,10 @@ export default defineConfig({
           include: ['src/**/*.test.tsx'],
           environment: 'jsdom',
           setupFiles: ['./vitest.setup.ts'],
+          // React 19 では `React.act` が development build にしか含まれない。
+          // testing-library が React.act を必要とするので test 実行は development 扱いにする。
+          // (NODE_ENV=test だと react.production.js が読まれて React.act が undefined になる)
+          env: { NODE_ENV: 'development' },
         },
       },
       {


### PR DESCRIPTION
Closes #11

## Summary

Chat にキャンバスのノードを「@メンション」のように添付できるようにする。
深掘り・分割・方針変更などをノード起点で AI に依頼できる。

- ChatContextBar (新コンポーネント) で添付状態を可視化し、ピッカーから type 別にノードを選べる
- 選択中ノード (キャンバスで 1 件選択中) を一発で添付するショートカット
- 添付ノードはサーバへ WS フレームの `contextNodeIds` に同梱され、
  ChatRunner が prompt 内の `<context_nodes>` ブロックに各ノードの内容を埋め込む
- ノードの「更新・削除」依頼は AI が直接行わず、proposal を新規生成して
  ユーザーが採用判断する既存フロー (ADR-0005) に乗せる

## 設計のポイント

- **永続化しない**: `chatContextNodeIds` は Zustand のメモリのみ。スレッド切替・close・reset で自動クリア。
  「ターンごとに添付し直しできる軽量な参照」という UX 設計。
- **削除済みノードに耐える**: 添付後にノードが消えても UI 表示と送信ペイロードからフィルタする (ai-engine 側でも getNode で None を返すと黙って捨てる)。
- **後方互換**: `contextNodeIds` は WS フレームで optional。空 / 省略時は従来挙動 (`<context_nodes>` ブロックを生成しない)。
- **AI に直接編集させない**: システムプロンプトに「ノードの更新・削除は proposal 経由で応答する」旨を明記。

## codex セカンドオピニオン対応 (追加コミット)

- **Major-1 (ロジックバグ)**: `<context_nodes>` が `<current_user_message>` より後ろに並んでしまうバグを修正。
  `runUserTurn` で空 assistant message を append する**前**に prompt をスナップショットする。
  回帰防止のため順序検証テストを追加 (履歴 → context → current の順で並ぶこと、新規 user 入力が conversation_history に埋もれないこと)。
- **Major-2**: `contextNodeIds` の最大件数を 20 に制限 (zod schema)。
- **Minor**: proposal ノードの `formatNodeForContext` から `sourceAgentId` を除外し、「未採用の AI 提案」note を追加。

## 残課題 (本 PR では対応せず)

- AI が「このノードを更新する」proposal を出す専用フロー (例: `adoptAs: 'replace-of:<id>'`) は未実装。
  当面は AI が「対案として新しい requirement proposal を作る」運用で代替する想定。
- 削除済みノードの提案フローも未実装。同上。
- ノード本体に「コンテキストに追加」ボタンを置くショートカット (現状は selected 経由) は将来追加可。
- ピッカーの絞り込み (検索ボックス・type フィルタ等) は別 issue で対応。ノード数が多いプロジェクトでの操作性向上。

## Test plan

- [x] `pnpm -r typecheck` 全 4 パッケージ green
- [x] `pnpm -r test` 全テスト green
  - ai-engine: `buildChatPrompt` / `formatNodeForContext` / runUserTurn の context 受け渡し + 順序検証 + proposal 整形 (新規 7 ケース)
  - frontend: store の add/remove/clear/sendChatMessage 経路 (新規 3 ケース) + ChatContextBar の UI (新規 5 ケース)
- [x] `pnpm --filter @tally/frontend exec playwright test e2e/chat-node-context.spec.ts` 5/5 green
- [ ] 手動 QA: 実際にチャットで添付 → 送信 → 添付ノード前提の応答が返ることを確認
- [ ] CodeRabbit / 人間レビュー

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チャットメッセージ送信時、プロジェクトノードをコンテキストとして添付できるようになりました
  * コンテキストノード管理UI：複数ノードの選択、個別削除、全削除機能に対応
  * AIエンジンは添付されたノード情報を自動的にメッセージ処理に含めます

* **バグ修正**
  * テスト環境でのエラー処理を改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->