### PR TITLE
chore: バージョン 2026.4.27.0 にバンプ

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tally",
-  "version": "2026.4.22.0",
+  "version": "2026.4.27.0",
   "private": true,
   "description": "既存システムの機能追加を、視覚的に要件定義するためのAIネイティブな思考環境",
   "author": "西立野 (Ignission)",


### PR DESCRIPTION
## Summary
- package.json のバージョンを `2026.4.22.0` → `2026.4.27.0` へ更新（リリース準備）

## 含まれる変更（前回バージョン以降）
- #14 ノード移動を Ctrl+Z で最大 3 回 Undo
- #15 キャンバスをスクロールパンに切替えノード操作感を改善
- #16 Chat にノードをコンテキストとして添付できるように

## Test plan
- [x] pnpm typecheck
- [x] pnpm lint
- [x] pnpm test (516 tests pass)
- [x] pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * バージョンをアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->