### PR TITLE
feat(ai-engine): ADR-0011 PR-E2 — OAuthClient + LoopbackCallbackServer

### DIFF
--- a/packages/ai-engine/src/oauth/index.ts
+++ b/packages/ai-engine/src/oauth/index.ts
@@ -1,0 +1,18 @@
+export {
+  type LoopbackCallback,
+  type LoopbackCallbackHandle,
+  type StartLoopbackCallbackServerOptions,
+  startLoopbackCallbackServer,
+} from './loopback-callback-server';
+export {
+  type BuildAuthorizationUrlInput,
+  buildAuthorizationUrl,
+  type ExchangeCodeInput,
+  exchangeCodeForToken,
+  generateOAuthState,
+  generatePkcePair,
+  type PkcePair,
+  type RefreshTokenInput,
+  refreshAccessToken,
+  type TokenExchangeResult,
+} from './oauth-client';

--- a/packages/ai-engine/src/oauth/loopback-callback-server.test.ts
+++ b/packages/ai-engine/src/oauth/loopback-callback-server.test.ts
@@ -92,6 +92,23 @@ describe('startLoopbackCallbackServer', () => {
     await expect(promise).rejects.toThrow(/server closed/);
   });
 
+  it('awaitCallback の多重呼び出しは throw (Promise 上書きでリーク防止)', async () => {
+    const handle = await startLoopbackCallbackServer();
+    try {
+      const first = handle.awaitCallback();
+      first.catch(() => {});
+      await expect(handle.awaitCallback()).rejects.toThrow(/can only be called once/);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('close 後の awaitCallback は throw (callback は永遠に届かないため即時失敗)', async () => {
+    const handle = await startLoopbackCallbackServer();
+    await handle.close();
+    await expect(handle.awaitCallback()).rejects.toThrow(/already closed/);
+  });
+
   it('preferredPort 指定時はその port で listen (port=0 は OS 採番)', async () => {
     // 0 を指定したときと省略時は同じ挙動 (OS 採番)。
     const a = await startLoopbackCallbackServer({ preferredPort: 0 });

--- a/packages/ai-engine/src/oauth/loopback-callback-server.test.ts
+++ b/packages/ai-engine/src/oauth/loopback-callback-server.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import { startLoopbackCallbackServer } from './loopback-callback-server';
+
+describe('startLoopbackCallbackServer', () => {
+  it('redirectUri は http://127.0.0.1:<port>/callback 形式 (port は OS 採番)', async () => {
+    const handle = await startLoopbackCallbackServer();
+    try {
+      expect(handle.redirectUri).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('callback URL を叩くと awaitCallback が code/state で resolve する', async () => {
+    const handle = await startLoopbackCallbackServer();
+    try {
+      const promise = handle.awaitCallback();
+      // ブラウザの redirect 相当を fetch で再現
+      const callbackRes = await fetch(`${handle.redirectUri}?code=AAA&state=xyz`);
+      expect(callbackRes.status).toBe(200);
+      const got = await promise;
+      expect(got).toEqual({ code: 'AAA', state: 'xyz' });
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('error= 付き callback は awaitCallback を reject + 400 を返す', async () => {
+    const handle = await startLoopbackCallbackServer();
+    try {
+      const promise = handle.awaitCallback();
+      // unhandled rejection 抑止: rejection を先に観測予約しておかないと、
+      // Vitest が fetch との race で reject を unhandled として記録する。
+      promise.catch(() => {});
+      const res = await fetch(
+        `${handle.redirectUri}?error=access_denied&error_description=user%20canceled`,
+      );
+      expect(res.status).toBe(400);
+      await expect(promise).rejects.toThrow(/access_denied/);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('code/state が無い callback は reject + 400', async () => {
+    const handle = await startLoopbackCallbackServer();
+    try {
+      const promise = handle.awaitCallback();
+      promise.catch(() => {});
+      const res = await fetch(`${handle.redirectUri}?code=onlyCode`);
+      expect(res.status).toBe(400);
+      await expect(promise).rejects.toThrow(/missing code or state/);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('callback path 以外のリクエストは 404 (favicon 等のノイズ対策)', async () => {
+    const handle = await startLoopbackCallbackServer();
+    try {
+      const res = await fetch(`http://127.0.0.1:${new URL(handle.redirectUri).port}/favicon.ico`);
+      expect(res.status).toBe(404);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('timeout で awaitCallback が reject する', async () => {
+    const handle = await startLoopbackCallbackServer();
+    try {
+      const start = Date.now();
+      await expect(handle.awaitCallback(50)).rejects.toThrow(/timeout/);
+      // 50ms ちょうどで止まる保証はないが、明らかに長すぎないことだけ確認
+      expect(Date.now() - start).toBeLessThan(2000);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('close は冪等 (二度呼んでも throw しない)', async () => {
+    const handle = await startLoopbackCallbackServer();
+    await handle.close();
+    await expect(handle.close()).resolves.toBeUndefined();
+  });
+
+  it('close() で pending な awaitCallback が reject される (永久 pending リーク防止)', async () => {
+    const handle = await startLoopbackCallbackServer();
+    const promise = handle.awaitCallback();
+    promise.catch(() => {});
+    await handle.close();
+    await expect(promise).rejects.toThrow(/server closed/);
+  });
+
+  it('preferredPort 指定時はその port で listen (port=0 は OS 採番)', async () => {
+    // 0 を指定したときと省略時は同じ挙動 (OS 採番)。
+    const a = await startLoopbackCallbackServer({ preferredPort: 0 });
+    try {
+      expect(Number(new URL(a.redirectUri).port)).toBeGreaterThan(0);
+    } finally {
+      await a.close();
+    }
+  });
+
+  it('path カスタマイズで redirect_uri が変わる', async () => {
+    const handle = await startLoopbackCallbackServer({ path: '/oauth/callback' });
+    try {
+      expect(handle.redirectUri).toMatch(/\/oauth\/callback$/);
+      const promise = handle.awaitCallback();
+      await fetch(`${handle.redirectUri}?code=A&state=S`);
+      const got = await promise;
+      expect(got.code).toBe('A');
+    } finally {
+      await handle.close();
+    }
+  });
+});

--- a/packages/ai-engine/src/oauth/loopback-callback-server.ts
+++ b/packages/ai-engine/src/oauth/loopback-callback-server.ts
@@ -1,0 +1,157 @@
+// ADR-0011 PR-E2: OAuth callback URL を loopback IP (127.0.0.1) で受ける一時 HTTP server。
+//
+// 設計判断:
+// - port は OS 採番 (0 を渡す)。固定 port にすると複数フローや他プロセスとの衝突が発生する。
+// - host は 127.0.0.1 固定。`localhost` だと IPv4/IPv6 どちらに bind するか実装依存で
+//   redirect_uri と一致しないことがある。
+// - state 検証は本モジュールで行わない (orchestrator 側の責務)。受領した code/state を
+//   そのまま callback API で返す。
+// - レスポンスは「タブを閉じてください」の最小 HTML。CSRF / XSS 対策で content type を
+//   text/plain でも良いが、UX を考えて最小 HTML にする。
+// - timeout は呼び出し側で指定 (デフォルト 5 分)。timeout で reject されたあとも close()
+//   を呼べばリソース解放される。
+
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export interface LoopbackCallback {
+  code: string;
+  state: string;
+}
+
+export interface LoopbackCallbackHandle {
+  // ブラウザに渡す redirect_uri (例: http://127.0.0.1:54321/callback)。
+  redirectUri: string;
+  // callback の到達を待つ。1 ハンドル 1 回だけ resolve する設計。
+  awaitCallback(timeoutMs?: number): Promise<LoopbackCallback>;
+  // server を閉じる。再呼び出しは no-op。
+  close(): Promise<void>;
+}
+
+export interface StartLoopbackCallbackServerOptions {
+  // callback path (default: '/callback')
+  path?: string;
+  // 希望 port (default: 0 = OS 採番)。固定 port が必要な provider 設定の場合のみ指定する。
+  preferredPort?: number;
+}
+
+export async function startLoopbackCallbackServer(
+  opts: StartLoopbackCallbackServerOptions = {},
+): Promise<LoopbackCallbackHandle> {
+  const callbackPath = opts.path ?? '/callback';
+  const port = opts.preferredPort ?? 0;
+
+  let resolveCallback: ((cb: LoopbackCallback) => void) | null = null;
+  let rejectCallback: ((err: Error) => void) | null = null;
+  let timeoutHandle: NodeJS.Timeout | null = null;
+
+  const cleanup = () => {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+      timeoutHandle = null;
+    }
+    resolveCallback = null;
+    rejectCallback = null;
+  };
+
+  const server: Server = createServer((req, res) => {
+    // path が違うものは 404。`favicon.ico` 等のノイズ対策。
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    if (url.pathname !== callbackPath) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not Found');
+      return;
+    }
+
+    const code = url.searchParams.get('code');
+    const state = url.searchParams.get('state');
+    const error = url.searchParams.get('error');
+    const errorDescription = url.searchParams.get('error_description');
+
+    if (error) {
+      // Provider が OAuth error を返したケース (access_denied 等)。
+      res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(
+        `<!doctype html><meta charset="utf-8"><h1>認証エラー</h1><p>${escapeHtml(error)}: ${escapeHtml(errorDescription ?? '')}</p>`,
+      );
+      const reject = rejectCallback;
+      cleanup();
+      reject?.(new Error(`OAuth callback error: ${error} ${errorDescription ?? ''}`));
+      return;
+    }
+
+    if (!code || !state) {
+      res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(
+        '<!doctype html><meta charset="utf-8"><h1>認証エラー</h1><p>code または state が見つかりません。</p>',
+      );
+      const reject = rejectCallback;
+      cleanup();
+      reject?.(new Error('OAuth callback missing code or state'));
+      return;
+    }
+
+    // 成功レスポンス。ブラウザに「タブを閉じて Tally に戻ってください」と促す。
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(
+      '<!doctype html><meta charset="utf-8"><h1>認証完了</h1><p>このタブを閉じて Tally に戻ってください。</p>',
+    );
+    const resolve = resolveCallback;
+    cleanup();
+    resolve?.({ code, state });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  const addr = server.address() as AddressInfo;
+  const redirectUri = `http://127.0.0.1:${addr.port}${callbackPath}`;
+
+  let closed = false;
+
+  return {
+    redirectUri,
+    async awaitCallback(timeoutMs = 5 * 60 * 1000): Promise<LoopbackCallback> {
+      return new Promise<LoopbackCallback>((resolve, reject) => {
+        resolveCallback = resolve;
+        rejectCallback = reject;
+        if (timeoutMs > 0) {
+          timeoutHandle = setTimeout(() => {
+            const r = rejectCallback;
+            cleanup();
+            r?.(new Error(`OAuth callback timeout after ${timeoutMs}ms`));
+          }, timeoutMs);
+        }
+      });
+    },
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      // cleanup() より前に pending な awaitCallback を reject 発火させる
+      // (cleanup() は rejectCallback を null 化するだけで reject を呼ばない)。
+      // これを先にしないと、ユーザーキャンセル等で close() された際に
+      // 既存の awaitCallback Promise が永遠に settle せずリークする (CR Major)。
+      const reject = rejectCallback;
+      cleanup();
+      reject?.(new Error('OAuth callback server closed before callback received'));
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+// 最小 HTML エスケープ (provider が返す error 文言を表示する用)。
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/packages/ai-engine/src/oauth/loopback-callback-server.ts
+++ b/packages/ai-engine/src/oauth/loopback-callback-server.ts
@@ -113,10 +113,22 @@ export async function startLoopbackCallbackServer(
   const redirectUri = `http://127.0.0.1:${addr.port}${callbackPath}`;
 
   let closed = false;
+  // 1 ハンドル 1 回だけ awaitCallback を許す。多重呼び出しは先行 Promise が
+  // 未解決のまま resolveCallback/rejectCallback を上書きされてリークするため
+  // 明示的に弾く (CR Major)。close 後の呼び出しも server が閉じている以上
+  // callback は届かないので即時失敗にする。
+  let awaitStarted = false;
 
   return {
     redirectUri,
     async awaitCallback(timeoutMs = 5 * 60 * 1000): Promise<LoopbackCallback> {
+      if (closed) {
+        throw new Error('OAuth callback server is already closed');
+      }
+      if (awaitStarted) {
+        throw new Error('awaitCallback can only be called once per handle');
+      }
+      awaitStarted = true;
       return new Promise<LoopbackCallback>((resolve, reject) => {
         resolveCallback = resolve;
         rejectCallback = reject;

--- a/packages/ai-engine/src/oauth/oauth-client.test.ts
+++ b/packages/ai-engine/src/oauth/oauth-client.test.ts
@@ -1,0 +1,218 @@
+import { ATLASSIAN_CLOUD_OAUTH } from '@tally/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildAuthorizationUrl,
+  exchangeCodeForToken,
+  generateOAuthState,
+  generatePkcePair,
+  refreshAccessToken,
+} from './oauth-client';
+
+describe('generatePkcePair', () => {
+  it('code_verifier は RFC 7636 §4.1 の長さ要件 (43-128 文字) を満たす', () => {
+    for (let i = 0; i < 5; i++) {
+      const { codeVerifier } = generatePkcePair();
+      expect(codeVerifier.length).toBeGreaterThanOrEqual(43);
+      expect(codeVerifier.length).toBeLessThanOrEqual(128);
+    }
+  });
+
+  it('code_challenge は code_verifier の SHA-256 を base64url した値', async () => {
+    const { codeVerifier, codeChallenge } = generatePkcePair();
+    // 自前で再計算して一致を確認
+    const { createHash } = await import('node:crypto');
+    const expected = createHash('sha256').update(codeVerifier).digest('base64url');
+    expect(codeChallenge).toBe(expected);
+  });
+
+  it('呼び出しごとに別の値を返す (entropy 確認の最小限)', () => {
+    const a = generatePkcePair();
+    const b = generatePkcePair();
+    expect(a.codeVerifier).not.toBe(b.codeVerifier);
+  });
+});
+
+describe('generateOAuthState', () => {
+  it('呼び出しごとに別の値を返す', () => {
+    const a = generateOAuthState();
+    const b = generateOAuthState();
+    expect(a).not.toBe(b);
+    expect(a.length).toBeGreaterThan(0);
+  });
+});
+
+describe('buildAuthorizationUrl', () => {
+  it('Atlassian の authorize URL に必須 PKCE / state / scope を載せる', () => {
+    const url = new URL(
+      buildAuthorizationUrl({
+        provider: ATLASSIAN_CLOUD_OAUTH,
+        clientId: 'cid-abc',
+        redirectUri: 'http://127.0.0.1:54321/callback',
+        scopes: ['read:jira-work', 'offline_access'],
+        state: 'state-xyz',
+        codeChallenge: 'challenge-abc',
+      }),
+    );
+    expect(url.origin + url.pathname).toBe(ATLASSIAN_CLOUD_OAUTH.authorizationEndpoint);
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('client_id')).toBe('cid-abc');
+    expect(url.searchParams.get('redirect_uri')).toBe('http://127.0.0.1:54321/callback');
+    expect(url.searchParams.get('scope')).toBe('read:jira-work offline_access');
+    expect(url.searchParams.get('state')).toBe('state-xyz');
+    expect(url.searchParams.get('code_challenge')).toBe('challenge-abc');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    // refresh_token を確実に得るため毎回 consent
+    expect(url.searchParams.get('prompt')).toBe('consent');
+  });
+
+  it('provider.audience がある場合は audience を付ける (Atlassian)', () => {
+    const url = new URL(
+      buildAuthorizationUrl({
+        provider: ATLASSIAN_CLOUD_OAUTH,
+        clientId: 'cid',
+        redirectUri: 'http://127.0.0.1:1/cb',
+        scopes: ['s'],
+        state: 's',
+        codeChallenge: 'c',
+      }),
+    );
+    expect(url.searchParams.get('audience')).toBe('api.atlassian.com');
+  });
+
+  it('provider.audience が無い場合は audience パラメータを付けない', () => {
+    // audience を除いた provider config を作る (exactOptionalPropertyTypes で undefined 代入を避ける)。
+    const { audience: _audience, ...noAudienceProvider } = ATLASSIAN_CLOUD_OAUTH;
+    const url = new URL(
+      buildAuthorizationUrl({
+        provider: noAudienceProvider,
+        clientId: 'cid',
+        redirectUri: 'http://127.0.0.1:1/cb',
+        scopes: ['s'],
+        state: 's',
+        codeChallenge: 'c',
+      }),
+    );
+    expect(url.searchParams.has('audience')).toBe(false);
+  });
+});
+
+describe('exchangeCodeForToken / refreshAccessToken', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('exchangeCodeForToken: token endpoint に form-encoded で POST し、camelCase で返す', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response(
+        JSON.stringify({
+          access_token: 'a-tok',
+          refresh_token: 'r-tok',
+          expires_in: 3600,
+          scope: 'read:jira-work offline_access',
+          token_type: 'Bearer',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await exchangeCodeForToken({
+      provider: ATLASSIAN_CLOUD_OAUTH,
+      clientId: 'cid',
+      code: 'auth-code',
+      redirectUri: 'http://127.0.0.1:54321/callback',
+      codeVerifier: 'verifier-xyz',
+    });
+
+    expect(result.accessToken).toBe('a-tok');
+    expect(result.refreshToken).toBe('r-tok');
+    expect(result.expiresIn).toBe(3600);
+    expect(result.scope).toBe('read:jira-work offline_access');
+    expect(result.tokenType).toBe('Bearer');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0];
+    if (!call) throw new Error('fetch not called');
+    const [endpoint, init] = call;
+    expect(endpoint).toBe(ATLASSIAN_CLOUD_OAUTH.tokenEndpoint);
+    expect(init?.method).toBe('POST');
+    const headers = init?.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+    const body = new URLSearchParams(init?.body as string);
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('code')).toBe('auth-code');
+    expect(body.get('code_verifier')).toBe('verifier-xyz');
+    expect(body.get('redirect_uri')).toBe('http://127.0.0.1:54321/callback');
+    expect(body.get('client_id')).toBe('cid');
+  });
+
+  it('exchangeCodeForToken: token_type が無いレスポンスは Bearer に default', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ access_token: 'a' }), { status: 200 })),
+    );
+    const result = await exchangeCodeForToken({
+      provider: ATLASSIAN_CLOUD_OAUTH,
+      clientId: 'cid',
+      code: 'c',
+      redirectUri: 'http://127.0.0.1:1/cb',
+      codeVerifier: 'v',
+    });
+    expect(result.tokenType).toBe('Bearer');
+  });
+
+  it('exchangeCodeForToken: 4xx/5xx は throw', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('invalid_grant', { status: 400 })),
+    );
+    await expect(
+      exchangeCodeForToken({
+        provider: ATLASSIAN_CLOUD_OAUTH,
+        clientId: 'cid',
+        code: 'c',
+        redirectUri: 'http://127.0.0.1:1/cb',
+        codeVerifier: 'v',
+      }),
+    ).rejects.toThrow(/token endpoint failed.*400/);
+  });
+
+  it('exchangeCodeForToken: access_token 欠落は throw (provider バグの早期検出)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({}), { status: 200 })),
+    );
+    await expect(
+      exchangeCodeForToken({
+        provider: ATLASSIAN_CLOUD_OAUTH,
+        clientId: 'cid',
+        code: 'c',
+        redirectUri: 'http://127.0.0.1:1/cb',
+        codeVerifier: 'v',
+      }),
+    ).rejects.toThrow(/missing access_token/);
+  });
+
+  it('refreshAccessToken: grant_type=refresh_token と refresh_token を form で送る', async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ access_token: 'new-tok' }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await refreshAccessToken({
+      provider: ATLASSIAN_CLOUD_OAUTH,
+      clientId: 'cid',
+      refreshToken: 'old-refresh',
+    });
+    expect(result.accessToken).toBe('new-tok');
+
+    const call = fetchMock.mock.calls[0];
+    if (!call) throw new Error('fetch not called');
+    const init = call[1];
+    const body = new URLSearchParams(init?.body as string);
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('old-refresh');
+    expect(body.get('client_id')).toBe('cid');
+  });
+});

--- a/packages/ai-engine/src/oauth/oauth-client.ts
+++ b/packages/ai-engine/src/oauth/oauth-client.ts
@@ -1,0 +1,157 @@
+// ADR-0011 PR-E2: 外部 MCP server に対する OAuth 2.1 (Authorization Code + PKCE) クライアント。
+// Node 標準のみで実装する (依存追加を避ける)。
+//
+// 設計判断:
+// - PKCE は S256 のみサポート (RFC 7636 推奨)。plain は実装しない。
+// - state は Tally 側で生成 + verify する (CSRF + 偽 callback 防止)。
+// - state / code_verifier / refresh_token を返さず、呼び出し側 (PR-E3 の Orchestrator) が
+//   管理する。本モジュールは純粋関数とネットワーク I/O のみに集中する。
+// - token endpoint は application/x-www-form-urlencoded で叩く (RFC 6749 §4.1.3)。
+
+import { createHash, randomBytes } from 'node:crypto';
+
+import type { OAuthProviderConfig } from '@tally/core';
+
+// PKCE pair。code_verifier はクライアント側で保持し、token 交換時に渡す。
+// code_challenge は authorization request の URL に乗せる。
+export interface PkcePair {
+  codeVerifier: string;
+  codeChallenge: string;
+}
+
+// RFC 7636 §4.1: code_verifier は 43-128 文字の URL-safe random。
+// 32 byte の random を base64url すると 43 文字になり下限を満たす。
+export function generatePkcePair(): PkcePair {
+  const codeVerifier = randomBytes(32).toString('base64url');
+  const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+  return { codeVerifier, codeChallenge };
+}
+
+// state は CSRF 防止用の opaque random。authorization request に乗せて、callback で
+// 一致を verify する。長すぎると URL が膨れるので 16 byte で十分 (entropy 128 bit)。
+export function generateOAuthState(): string {
+  return randomBytes(16).toString('base64url');
+}
+
+export interface BuildAuthorizationUrlInput {
+  provider: OAuthProviderConfig;
+  clientId: string;
+  redirectUri: string;
+  scopes: readonly string[];
+  state: string;
+  codeChallenge: string;
+}
+
+// Authorization URL を組み立てる (Authorization Code + PKCE フロー)。
+// Atlassian は audience が必須なので provider.audience があれば付ける。
+// prompt=consent を付けて refresh_token を確実に取得する (provider 依存だが大半で有効)。
+export function buildAuthorizationUrl(input: BuildAuthorizationUrlInput): string {
+  const url = new URL(input.provider.authorizationEndpoint);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', input.clientId);
+  url.searchParams.set('redirect_uri', input.redirectUri);
+  url.searchParams.set('scope', input.scopes.join(' '));
+  url.searchParams.set('state', input.state);
+  url.searchParams.set('code_challenge', input.codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  if (input.provider.audience) {
+    url.searchParams.set('audience', input.provider.audience);
+  }
+  // prompt は provider 設定 (例: Atlassian は 'consent') で指定された場合のみ付ける。
+  // ハードコードすると prompt 不可 / 別値必須の provider を将来追加した際に詰む。
+  if (input.provider.prompt) {
+    url.searchParams.set('prompt', input.provider.prompt);
+  }
+  return url.toString();
+}
+
+// Token endpoint からの response。snake_case のまま受け、呼び出し側が camelCase に変換する。
+interface TokenEndpointResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+}
+
+// 呼び出し側に返す形 (camelCase)。
+export interface TokenExchangeResult {
+  accessToken: string;
+  refreshToken?: string;
+  // Token endpoint レスポンスの expires_in (秒)。expiresAt 化は呼び出し側で行う。
+  expiresIn?: number;
+  // 実際に許可された scope (space 区切り、provider が絞った場合に把握)。
+  scope?: string;
+  tokenType: string;
+}
+
+export interface ExchangeCodeInput {
+  provider: OAuthProviderConfig;
+  clientId: string;
+  code: string;
+  redirectUri: string;
+  codeVerifier: string;
+}
+
+// Authorization code を access_token に交換する (RFC 6749 §4.1.3 + RFC 7636)。
+// public client (PKCE 経由) なので client_secret は使わない。
+export async function exchangeCodeForToken(input: ExchangeCodeInput): Promise<TokenExchangeResult> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: input.clientId,
+    code: input.code,
+    redirect_uri: input.redirectUri,
+    code_verifier: input.codeVerifier,
+  });
+  return await postTokenEndpoint(input.provider.tokenEndpoint, body);
+}
+
+export interface RefreshTokenInput {
+  provider: OAuthProviderConfig;
+  clientId: string;
+  refreshToken: string;
+}
+
+// Refresh token を使って access_token を更新する (RFC 6749 §6)。
+// 一部 provider は refresh 時に新しい refresh_token を返すので、戻り値の refreshToken を
+// 必ず token store に書き戻す必要がある (rotation policy)。
+export async function refreshAccessToken(input: RefreshTokenInput): Promise<TokenExchangeResult> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: input.clientId,
+    refresh_token: input.refreshToken,
+  });
+  return await postTokenEndpoint(input.provider.tokenEndpoint, body);
+}
+
+async function postTokenEndpoint(
+  endpoint: string,
+  body: URLSearchParams,
+): Promise<TokenExchangeResult> {
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    // エラー本文には機密が含まれる可能性が低いが、念のため最初の 512 文字に切る。
+    const text = (await res.text().catch(() => '')).slice(0, 512);
+    throw new Error(`token endpoint failed (${res.status}): ${text}`);
+  }
+  const json = (await res.json()) as TokenEndpointResponse;
+  if (typeof json.access_token !== 'string' || json.access_token === '') {
+    throw new Error('token endpoint response missing access_token');
+  }
+  // exactOptionalPropertyTypes 下では `?: string` に `string | undefined` を直接 assign
+  // できないので、各 optional は値が存在するときだけ object に乗せる (spread 経由)。
+  return {
+    accessToken: json.access_token,
+    ...(json.refresh_token !== undefined ? { refreshToken: json.refresh_token } : {}),
+    ...(json.expires_in !== undefined ? { expiresIn: json.expires_in } : {}),
+    ...(json.scope !== undefined ? { scope: json.scope } : {}),
+    tokenType: json.token_type ?? 'Bearer',
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,12 @@ export type { StoryProgress } from './logic/story';
 export { computeStoryProgress, isStoryComplete } from './logic/story';
 export type { EdgeMeta, NodeMeta } from './meta';
 export { EDGE_META, NODE_META } from './meta';
-export { ATLASSIAN_CLOUD_OAUTH, OAUTH_REGISTRY, type OAuthKind } from './oauth';
+export {
+  ATLASSIAN_CLOUD_OAUTH,
+  OAUTH_REGISTRY,
+  type OAuthKind,
+  type OAuthProviderConfig,
+} from './oauth';
 export type { Codebase, McpOAuthConfig, McpOAuthToken, McpServerConfig } from './schema';
 export {
   ChatBlockSchema,

--- a/packages/core/src/oauth/atlassian.ts
+++ b/packages/core/src/oauth/atlassian.ts
@@ -19,6 +19,10 @@ export interface OAuthProviderConfig {
   // requested scopes 未指定時の default。refresh_token に必要な scope (例: offline_access)
   // はここに含める想定。
   defaultScopes: readonly string[];
+  // authorization request に付ける prompt パラメータ (Atlassian / Auth0 で 'consent' を
+  // 指定すると refresh_token を確実に得られる)。provider が prompt を受け付けない場合は
+  // undefined にして送らない。`buildAuthorizationUrl` ではここに値があるときだけ url に乗せる。
+  prompt?: string;
 }
 
 export const ATLASSIAN_CLOUD_OAUTH: OAuthProviderConfig = {
@@ -32,11 +36,14 @@ export const ATLASSIAN_CLOUD_OAUTH: OAuthProviderConfig = {
   // でユーザーが追加指定する。
   // refresh_token を得るには `offline_access` が必須。
   defaultScopes: ['read:jira-work', 'read:jira-user', 'offline_access'],
+  // Atlassian は再ログイン時 (=既存 grant あり) に refresh_token が返らないことがあるため、
+  // 毎回 consent を要求して確実に refresh_token を得る。
+  prompt: 'consent',
 };
 
 // kind ごとの OAuth endpoint registry。kind が増えたらここにエントリを追加する。
-export const OAUTH_REGISTRY: Readonly<Record<string, OAuthProviderConfig>> = {
+export const OAUTH_REGISTRY = {
   atlassian: ATLASSIAN_CLOUD_OAUTH,
-};
+} as const satisfies Readonly<Record<string, OAuthProviderConfig>>;
 
 export type OAuthKind = keyof typeof OAUTH_REGISTRY;

--- a/packages/core/src/oauth/index.ts
+++ b/packages/core/src/oauth/index.ts
@@ -1,1 +1,6 @@
-export { ATLASSIAN_CLOUD_OAUTH, OAUTH_REGISTRY, type OAuthKind } from './atlassian';
+export {
+  ATLASSIAN_CLOUD_OAUTH,
+  OAUTH_REGISTRY,
+  type OAuthKind,
+  type OAuthProviderConfig,
+} from './atlassian';


### PR DESCRIPTION
## Summary

ADR-0011 (Tally 側で OAuth 2.1 フローを管理する) の実装段階 2。issue #28 への対応として、外部 MCP server に対する **OAuth 2.1 (Authorization Code + PKCE) クライアント**を実装する。

PR-E1 (#29 merged) で作った schema / token store の上に乗る形。**本 PR でも OAuth フロー全体は接続されない** (PR-E3 で API + UI、PR-E4 で SDK 統合)。

## 設計判断

- Node 標準のみ (依存追加なし、`oauth4webapi` 等は使わない)
- PKCE は **S256 のみ** (RFC 7636 推奨)、plain は実装しない
- `state` の verify は呼び出し側 (PR-E3 の Orchestrator) の責務
- LoopbackCallbackServer は **port=0 で OS 採番**、host は `127.0.0.1` 固定 (`localhost` だと IPv4/IPv6 衝突)
- token endpoint は `application/x-www-form-urlencoded` (RFC 6749 §4.1.3 準拠)
- public client (PKCE 経由) なので `client_secret` は使わない

## 変更ファイル

### packages/ai-engine/src/oauth/ (新規)
- `oauth-client.ts`: PKCE pair / state / authorization URL / token 交換 / refresh
- `loopback-callback-server.ts`: 一時 HTTP server (127.0.0.1, port=0, callback path 限定、HTML escape、timeout、冪等 close、pending reject 発火)
- `index.ts`: 公開 export
- 関連 test 22 件

### packages/core (拡張)
- `OAuthProviderConfig.prompt?: string`: Atlassian 用 'consent' を provider 設定で制御（ハードコード回避）
- `OAUTH_REGISTRY` を `as const satisfies Readonly<...>` に変更（リテラル型維持 + contract check）
- `OAuthProviderConfig` 型を core から公開 export

## codex セカンドオピニオン対応 (push 直前 review)

| 重要度 | 件 | 対応 |
|--------|-----|------|
| MEDIUM | 2 | `close()` で pending `awaitCallback` を reject 発火 / `prompt` を `OAuthProviderConfig` 化 |
| LOW | 2 | `access_token` を `typeof + 空文字列` で明示チェック / close 中 pending reject の test |

## Test plan

- [x] pnpm typecheck (4/4 PASS)
- [x] pnpm test (core 99 + storage 97 + ai-engine 235 + frontend 273 = 704 PASS)
- [x] pnpm lint (exit 0)
- [ ] PR-E3 で API endpoint と UI を繋ぐ際に LoopbackCallbackServer が想定通り動くか結合確認 (本 PR 範囲外)

## Related

- issue #28
- ADR-0011: https://github.com/ignission/tally/blob/main/docs/adr/0011-tally-managed-oauth-flow.md
- PR-E1 (merged): #29
- 後続: PR-E3 (API+UI) / PR-E4 (chat-runner 削除) / PR-E5 (E2E + docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  - OAuth 2.1認証フロー（PKCE対応）を追加しました。
  - 認可コードからアクセストークンへの交換機能を実装しました。
  - トークン更新機能を追加しました。
  - ローカルコールバック サーバーを実装し、OAuth認証の受け取りに対応しました。
  - Atlassian OAuth統合を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->